### PR TITLE
Mak/logging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,6 @@ default:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/             # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^stg-v[0-9]+\.[0-9]+.*$/         # i.e. stg-v1.0, stg-v2.1rc1
-    - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # Manual Deployment with PRs
 
 .production-refs:                  &production-refs
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ default:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/             # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^stg-v[0-9]+\.[0-9]+.*$/         # i.e. stg-v1.0, stg-v2.1rc1
-    - if: $CI_JOB_MANUAL == true && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # Manual Deployment with PRs
+    - if: $CI_JOB_MANUAL == "true" && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # Manual Deployment with PRs
 
 .production-refs:                  &production-refs
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ default:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/             # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^stg-v[0-9]+\.[0-9]+.*$/         # i.e. stg-v1.0, stg-v2.1rc1
-    - if: $CI_JOB_MANUAL == "true" && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # Manual Deployment with PRs
+    - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # Manual Deployment with PRs
 
 .production-refs:                  &production-refs
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,6 +159,7 @@ build-docker-ci:
       --set env.GITLAB_ACCESS_TOKEN="$GITLAB_ACCESS_TOKEN"
       --set env.GITLAB_ACCESS_TOKEN_USERNAME="$GITLAB_ACCESS_TOKEN_USERNAME"
       --set env.LOG_FORMAT=json
+      --set env.MIN_LOG_LEVEL=debug
 
 # TODO: rename to .deploy-k8s when prod is moved to parity-prod
 .deploy-k8s-stg:                   &deploy-k8s-stg
@@ -192,6 +193,7 @@ build-docker-ci:
       --set env.TASK_DB_VERSION="$TASK_DB_VERSION"
       --set env.PING_PORT="$PING_PORT"
       --set env.LOG_FORMAT=json
+      --set env.MIN_LOG_LEVEL=debug
       $CI_PROJECT_NAME helm-stg/
 
 .uninstall-deployment:             &uninstall-deployment

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,7 @@ default:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/             # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^stg-v[0-9]+\.[0-9]+.*$/         # i.e. stg-v1.0, stg-v2.1rc1
+    - if: $CI_JOB_MANUAL == true && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # Manual Deployment with PRs
 
 .production-refs:                  &production-refs
   rules:

--- a/deploy-stg.sh
+++ b/deploy-stg.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+timestamp=$(date +%s)
+
+# remember initial branch
+dev_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# replace possible "/" with "-"
+dev_branch_sanitized=${dev_branch/\//-}
+
+stg_branch="stg-v0.0.${timestamp}-${dev_branch_sanitized}"
+
+git checkout -b "$stg_branch"
+git push origin "$stg_branch"
+
+# wait a bit before deleting branch, so gitlab triggers pipeline
+sleep 10
+
+git push origin --delete "$stg_branch"
+
+# get back to initial branch
+git checkout "$dev_branch"

--- a/helm-stg/values-parity-stg.yaml
+++ b/helm-stg/values-parity-stg.yaml
@@ -21,6 +21,7 @@ common:
     TASK_DB_VERSION: v3
     PING_PORT: 3001
     LOG_FORMAT: json
+    MIN_LOG_LEVEL: debug
     DB_CLIENT: postgres
     DB_PORT: 5432
   secrets:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "4.17.21",
     "matrix-bot-sdk": "0.6.3",
     "node-fetch": "^2.6.7",
-    "opstooling-js": "https://github.com/paritytech/opstooling-js#v0.0.15",
+    "opstooling-js": "https://github.com/paritytech/opstooling-js#v0.0.16",
     "opstooling-js-style": "https://github.com/paritytech/opstooling-js-style.git#^v1.0.0",
     "probot": "^12.2.8",
     "stoppable": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "4.17.21",
     "matrix-bot-sdk": "0.6.3",
     "node-fetch": "^2.6.7",
-    "opstooling-js": "https://github.com/paritytech/opstooling-js#v0.0.14",
+    "opstooling-js": "https://github.com/paritytech/opstooling-js#v0.0.15",
     "opstooling-js-style": "https://github.com/paritytech/opstooling-js-style.git#^v1.0.0",
     "probot": "^12.2.8",
     "stoppable": "1.1.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -151,7 +151,7 @@ export const setupApi = (ctx: Context, server: Server): void => {
       )
     }
 
-    const command = await validateSingleShellCommand([...configuration.commandStart, ...args].join(" "))
+    const command = await validateSingleShellCommand(ctx, [...configuration.commandStart, ...args].join(" "))
     if (command instanceof Error) {
       return errorResponse(res, next, 422, command.message)
     }

--- a/src/bot.spec.ts
+++ b/src/bot.spec.ts
@@ -121,7 +121,7 @@ const dataProvider: DataProvider[] = [
 describe("parsePullRequestBotCommandLine", () => {
   for (const { suitName, commandLine, expectedResponse } of dataProvider) {
     test(`test commandLine: ${commandLine} [${suitName}]`, async () => {
-      const res = await parsePullRequestBotCommandLine(commandLine)
+      const res = await parsePullRequestBotCommandLine(commandLine, { logger })
       expect(res).toEqual(expectedResponse)
     })
   }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -402,7 +402,7 @@ const setupEvent = <E extends WebhookEvents>(
     const eventLogger = logger.child({ eventId: event.id, eventName })
     const ctx: Context = { ...parentCtx, logger: eventLogger }
 
-    eventLogger.info({ event, eventName }, "Received bot event")
+    eventLogger.info(`Received bot event ${eventName}`, null, [event, eventName])
 
     const installationId: number | undefined =
       "installation" in event.payload ? event.payload.installation?.id : undefined

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,14 +5,15 @@ import glob from "glob"
 import path from "path"
 
 import { config } from "src/config"
+import { LoggerContext } from "src/logger"
 import { CmdJson } from "src/schema/schema.cmd"
 import { CommandRunner } from "src/shell"
 import { CommandConfigs } from "src/types"
 
 const CMD_ROOT_FOLDER = "commands"
 
-export async function fetchCommandsConfiguration(devBranch?: string): Promise<CommandConfigs> {
-  const cmdRunner = new CommandRunner()
+export async function fetchCommandsConfiguration(ctx: LoggerContext, devBranch?: string): Promise<CommandConfigs> {
+  const cmdRunner = new CommandRunner(ctx)
   const scriptsFolder = "scripts"
   const scriptsPath = path.join(config.dataPath, scriptsFolder)
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -45,10 +45,10 @@ export const isRequesterAllowed = async (
   octokit: ExtendedOctokit,
   username: string,
 ): Promise<boolean> => {
-  const { allowedOrganizations } = ctx
+  const { allowedOrganizations, logger } = ctx
 
   for (const organizationId of allowedOrganizations) {
-    if (await isOrganizationMember({ organizationId, username, octokit })) {
+    if (await isOrganizationMember({ organizationId, username, octokit, logger })) {
       return true
     }
   }
@@ -75,11 +75,11 @@ export const prepareBranch = async function* (
     itemsToRedact.push(token)
   }
 
-  const cmdRunner = new CommandRunner({ itemsToRedact })
+  const cmdRunner = new CommandRunner(ctx, { itemsToRedact })
 
   yield cmdRunner.run("mkdir", ["-p", repoPath])
 
-  const repoCmdRunner = new CommandRunner({ itemsToRedact, cwd: repoPath })
+  const repoCmdRunner = new CommandRunner(ctx, { itemsToRedact, cwd: repoPath })
 
   // Clone the repository if it does not exist
   yield repoCmdRunner.run("git", ["clone", "--quiet", `${url}/${upstream.owner}/${upstream.repo}.git`, repoPath], {

--- a/src/github.ts
+++ b/src/github.ts
@@ -2,9 +2,9 @@ import { OctokitResponse } from "@octokit/plugin-paginate-rest/dist-types/types"
 import { RequestError } from "@octokit/request-error"
 import { EndpointInterface, Endpoints, RequestInterface } from "@octokit/types"
 import { Mutex } from "async-mutex"
+import { Logger } from "opstooling-js"
 import { Probot } from "probot"
 
-import { logger } from "src/logger"
 import { PullRequestTask } from "src/task"
 import { CommandOutput, Context } from "src/types"
 import { displayError, Err, millisecondsDelay, Ok } from "src/utils"
@@ -35,7 +35,8 @@ let requestDelay = Promise.resolve()
 const rateLimitRemainingHeader = "x-ratelimit-remaining"
 const rateLimitResetHeader = "x-ratelimit-reset"
 const retryAfterHeader = "retry-after"
-export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
+export const getOctokit = (octokit: Octokit, ctx: Context): ExtendedOctokit => {
+  const { logger: log } = ctx
   /*
     Check that this Octokit instance has not been augmented before because
     side-effects of this function should not be stacked; e.g. registering
@@ -53,7 +54,7 @@ export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
   })
 
   octokit.hook.wrap("request", async (request, options) => {
-    logger.debug({ request, options }, "Preparing to send a request to the GitHub API")
+    log.debug({ request, options }, "Preparing to send a request to the GitHub API")
 
     let triesCount = 0
     /* FIXME to get a good return type here, the function should be split.
@@ -67,7 +68,7 @@ export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
 
         for (; triesCount < 3; triesCount++) {
           if (triesCount) {
-            logger.debug({}, `Retrying Octokit request (tries so far: ${triesCount})`)
+            log.debug({}, `Retrying Octokit request (tries so far: ${triesCount})`)
           }
 
           try {
@@ -78,7 +79,7 @@ export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
             }
 
             const { status, message } = error
-            logger.error(
+            log.error(
               error,
               `Error while querying GitHub API: url: ${error.request.url}, status: ${status}, message: ${message}`,
             )
@@ -103,14 +104,14 @@ export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
                     const { headers } = response
                     if (parseInt(headers[rateLimitRemainingHeader] ?? "") === 0) {
                       // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limit-http-headers
-                      logger.warn(
+                      log.warn(
                         {},
                         `GitHub API limits were hit! The "${rateLimitResetHeader}" response header will be read to figure out until when we're supposed to wait...`,
                       )
                       const rateLimitResetHeaderValue = headers[rateLimitResetHeader]
                       const resetEpoch = parseInt(rateLimitResetHeaderValue ?? "") * 1000
                       if (Number.isNaN(resetEpoch)) {
-                        logger.error(
+                        log.error(
                           { rateLimitResetHeaderValue, rateLimitResetHeader, headers },
                           `GitHub response header "${rateLimitResetHeader}" could not be parsed as epoch`,
                         )
@@ -118,7 +119,7 @@ export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
                         const currentEpoch = Date.now()
                         const duration = resetEpoch - currentEpoch
                         if (duration < 0) {
-                          logger.error(
+                          log.error(
                             { rateLimitResetHeaderValue, resetEpoch, currentEpoch, headers },
                             `Parsed epoch value for GitHub response header "${rateLimitResetHeader}" is smaller than the current date`,
                           )
@@ -131,7 +132,7 @@ export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
                       const retryAfterHeaderValue = headers[retryAfterHeader]
                       const duration = parseInt(String(retryAfterHeaderValue)) * 1000
                       if (Number.isNaN(duration)) {
-                        logger.error(
+                        log.error(
                           { retryAfterHeader, retryAfterHeaderValue, headers },
                           `GitHub response header "${retryAfterHeader}" could not be parsed as seconds`,
                         )
@@ -148,7 +149,7 @@ export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
           */
                       !isApiRateLimitResponse
                     ) {
-                      logger.info(
+                      log.info(
                         { headers, fallbackWaitDuration, message },
                         "Falling back to default wait duration since other heuristics were not fulfilled",
                       )
@@ -160,7 +161,7 @@ export const getOctokit = (octokit: Octokit): ExtendedOctokit => {
               return new Err(error)
             }
 
-            logger.debug({}, `Waiting for ${waitDuration}ms until requests can be made again...`)
+            log.debug({}, `Waiting for ${waitDuration}ms until requests can be made again...`)
             await millisecondsDelay(waitDuration)
           }
         }
@@ -196,12 +197,12 @@ export type Comment = {
   data: unknown | null // TODO: quite a complex type inside
 }
 export const createComment = async (
-  { disablePRComment }: Context,
+  { disablePRComment, logger: log }: Context,
   octokit: Octokit,
   ...args: Parameters<typeof octokit.issues.createComment>
 ): Promise<Comment> => {
   if (disablePRComment) {
-    logger.info({ call: "createComment", args }, "createComment")
+    log.info({ call: "createComment", args }, "createComment")
     return { status: 201, id: 0, htmlUrl: "", data: null }
   } else {
     const { data, status } = await octokit.issues.createComment(...args)
@@ -210,12 +211,12 @@ export const createComment = async (
 }
 
 export const updateComment = async (
-  { disablePRComment }: Context,
+  { disablePRComment, logger: log }: Context,
   octokit: Octokit,
   ...args: Parameters<typeof octokit.issues.updateComment>
 ): Promise<void> => {
   if (disablePRComment) {
-    logger.info({ call: "updateComment", args }, "createComment")
+    log.info({ call: "updateComment", args }, "createComment")
   } else {
     await octokit.issues.updateComment(...args)
   }
@@ -225,10 +226,12 @@ export const isOrganizationMember = async ({
   organizationId,
   username,
   octokit,
+  logger: log,
 }: {
   organizationId: number
   username: string
   octokit: ExtendedOctokit
+  logger: Logger
 }): Promise<boolean> => {
   try {
     const response = await octokit.orgs.userMembershipByOrganizationId({ organization_id: organizationId, username })
@@ -242,10 +245,10 @@ export const isOrganizationMember = async ({
         doesn't need to be flagged as an error
       */
       if (error?.status !== 404) {
-        logger.fatal(error, "Organization membership API call responded with unexpected status code")
+        log.fatal(error, "Organization membership API call responded with unexpected status code")
       }
     } else {
-      logger.fatal(error, "Caught unexpected error in isOrganizationMember")
+      log.fatal(error, "Caught unexpected error in isOrganizationMember")
     }
     return false
   }

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -114,13 +114,16 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task): Prom
 
   const branchPresenceUrl = `${gitlabProjectApi}/repository/branches/${branchNameUrlEncoded}`
   for (let waitForBranchTryCount = 0; waitForBranchTryCount < waitForBranchMaxTries; waitForBranchTryCount++) {
-    logger.info(branchPresenceUrl, `Sending request to see if the branch for task ${task.id} is ready`)
+    logger.debug({ branchPresenceUrl }, `Sending request to see if the branch for task ${task.id} is ready`)
     const response = await fetch(branchPresenceUrl, { headers: { "PRIVATE-TOKEN": gitlab.accessToken } })
     if (
       // The branch was not yet registered on GitLab; wait for it...
       response.status === 404
     ) {
-      logger.info(`Branch of task ${task.id} was not found. Waiting before retrying...`)
+      logger.warn(
+        { branchPresenceUrl, task, response },
+        `Branch of task ${task.id} was not found. Waiting before retrying...`,
+      )
       await millisecondsDelay(waitForBranchRetryDelay)
     } else if (response.ok) {
       wasBranchRegistered = true
@@ -137,7 +140,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task): Prom
   }
 
   const pipelineCreationUrl = `${gitlabProjectApi}/pipeline?ref=${branchNameUrlEncoded}`
-  logger.info(pipelineCreationUrl, `Sending request to create a pipeline for task ${task.id}`)
+  logger.debug({ pipelineCreationUrl, task }, `Sending request to create a pipeline for task ${task.id}`)
   const pipeline = await validatedFetch<{
     id: number
     project_id: number
@@ -147,10 +150,10 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task): Prom
       .keys({ id: Joi.number().required(), project_id: Joi.number().required() })
       .options({ allowUnknown: true }),
   )
-  logger.info(pipeline, `Created pipeline for task ${task.id}`)
+  logger.info({ pipeline, task }, `Created pipeline for task ${task.id}`)
 
   const jobFetchUrl = `${gitlabProjectApi}/pipelines/${pipeline.id}/jobs`
-  logger.info(jobFetchUrl, `Sending request to fetch the GitLab job created for task ${task.id}`)
+  logger.debug({ jobFetchUrl, task, pipeline }, `Sending request to fetch the GitLab job created for task ${task.id}`)
   const [job] = await validatedFetch<
     [
       {
@@ -164,7 +167,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task): Prom
       .length(1)
       .required(),
   )
-  logger.info(job, `Fetched job for task ${task.id}`)
+  logger.info({ job, task, pipeline }, `Fetched job for task ${task.id}`)
 
   return getAliveTaskGitlabContext(ctx, { id: pipeline.id, projectId: pipeline.project_id, jobWebUrl: job.web_url })
 }
@@ -235,7 +238,7 @@ export const cancelGitlabPipeline = async (
   { gitlab, logger }: Context,
   pipeline: TaskGitlabPipeline,
 ): Promise<void> => {
-  logger.info(pipeline, "Cancelling GitLab pipeline")
+  logger.info({ pipeline }, "Cancelling GitLab pipeline")
   await validatedFetch(
     fetch(
       /*

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -26,7 +26,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task): Prom
   const { logger, gitlab } = ctx
   const { pipelineScripts } = config
 
-  const cmdRunner = new CommandRunner({ itemsToRedact: [gitlab.accessToken], cwd: task.repoPath })
+  const cmdRunner = new CommandRunner(ctx, { itemsToRedact: [gitlab.accessToken], cwd: task.repoPath })
 
   /*
     Save the head SHA before doing any modifications to the branch so that

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,8 @@ import { Logger, LoggerOptions } from "opstooling-js"
 import { Logger as ProbotLogger } from "pino"
 import { getLog } from "probot/lib/helpers/get-log"
 
+import { Context } from "src/types"
+
 export const logFormat = ((): "json" | null => {
   const value = process.env.LOG_FORMAT
   switch (value) {
@@ -37,6 +39,7 @@ export const minLogLevel = ((): "debug" | "info" | "warn" | "error" => {
 
 const loggerOptions: LoggerOptions = { name: "command-bot", minLogLevel, logFormat, impl: console }
 
+export type LoggerContext = Pick<Context, "logger">
 export const logger = new Logger(loggerOptions)
 
 export let probotLogger: ProbotLogger | undefined = undefined

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,12 +17,13 @@ export const logFormat = ((): "json" | null => {
   }
 })()
 
-export const minLogLevel = ((): "info" | "warn" | "error" => {
+export const minLogLevel = ((): "debug" | "info" | "warn" | "error" => {
   const value: string | undefined = process.env.MIN_LOG_LEVEL
   switch (value) {
     case undefined: {
       return "info"
     }
+    case "debug":
     case "info":
     case "warn":
     case "error": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ const main = async () => {
   })
 
   await server.start()
-  logger.info("Probot has started!")
+  logger.info({}, "Probot has started!")
 
   if (config.pingPort) {
     // Signal that we have started listening until Probot kicks in

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -33,10 +33,10 @@ export const setup = async (
 
   const taskDb = new TaskDB(getDb(taskDbPath))
   const tasks = await getSortedTasks({ taskDb, logger })
-  logger.info(tasks, "Tasks found at the start of the application")
+  logger.info({ tasks }, "Tasks found at the start of the application")
 
   if (shouldClearTaskDatabaseOnStart) {
-    logger.info("Clearing the task database during setup")
+    logger.info({}, "Clearing the task database during setup")
     for (const { id } of tasks) {
       await taskDb.db.del(id)
     }
@@ -84,7 +84,7 @@ export const setup = async (
         matrixClient
           .start()
           .then(() => {
-            logger.info(`Connected to Matrix homeserver ${matrixConfiguration.homeServer}`)
+            logger.info({}, `Connected to Matrix homeserver ${matrixConfiguration.homeServer}`)
             resolve(new Ok(matrixClient))
           })
           .catch((error) => {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -6,7 +6,7 @@ import { Logger } from "opstooling-js"
 import path from "path"
 import { Readable as ReadableStream } from "stream"
 
-import { logger } from "src/logger"
+import { LoggerContext } from "src/logger"
 import { ToString } from "src/types"
 import { redact } from "src/utils"
 
@@ -33,6 +33,7 @@ export class CommandRunner {
   private commandOutputBuffer: ["stdout" | "stderr", string][] = []
 
   constructor(
+    private ctx: LoggerContext,
     private configuration?: {
       itemsToRedact?: string[]
       shouldTrackProgress?: boolean
@@ -40,6 +41,7 @@ export class CommandRunner {
       onChild?: (child: ChildProcess) => void
     },
   ) {
+    const { logger } = ctx
     this.logger = logger.child({ commandId: randomUUID() })
   }
 
@@ -136,8 +138,9 @@ export class CommandRunner {
   }
 }
 
-export const validateSingleShellCommand = async (command: string): Promise<string | Error> => {
-  const cmdRunner = new CommandRunner()
+export const validateSingleShellCommand = async (ctx: LoggerContext, command: string): Promise<string | Error> => {
+  const { logger } = ctx
+  const cmdRunner = new CommandRunner(ctx)
   const commandAstText = await cmdRunner.run("shfmt", ["--tojson"], { stdinInput: command })
   if (commandAstText instanceof Error) {
     return new Error(`Command AST could not be parsed for "${command}"`)

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -64,7 +64,7 @@ export class CommandRunner {
 
       const rawCommand = `${execPath} ${args.join(" ")}`
       const commandDisplayed = itemsToRedact?.length ? redact(rawCommand, itemsToRedact) : rawCommand
-      log.info(`Executing command ${commandDisplayed}`)
+      log.info({ execPath, args }, `Executing command ${commandDisplayed}`)
 
       const child = spawn(execPath, args, { cwd, stdio: "pipe" })
 
@@ -87,6 +87,7 @@ export class CommandRunner {
 
       child.on("close", (exitCode, signal) => {
         log.info(
+          { exitCode, signal },
           `Command "${commandDisplayed}" finished with exit code ${exitCode ?? "??"}${
             signal ? `and signal ${signal}` : ""
           }`,
@@ -144,7 +145,7 @@ export const validateSingleShellCommand = async (command: string): Promise<strin
   const commandAst = JSON.parse(commandAstText) as {
     Stmts: { Cmd: { Type?: string } }[]
   }
-  logger.info(commandAst.Stmts[0].Cmd, `Parsed AST for "${command}"`)
+  logger.debug(commandAst.Stmts[0].Cmd, `Parsed AST for "${command}"`)
   if (commandAst.Stmts.length !== 1 || commandAst.Stmts[0].Cmd.Type !== "CallExpr") {
     return new Error(`Command "${command}" failed validation: the resulting command line should have a single command`)
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "typeRoots": ["./node_modules/@types", "./src", "opstooling-js"],
     "plugins": [
       {
-        "transform": "typescript-transform-paths"
+        "transform": "typescript-transform-paths",
+        "exclude": ["**/node_modules/**"]
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5826,9 +5826,9 @@ onetime@^5.1.2:
     prettier "^2.6.2"
     prettier-plugin-compactify "^0.1.6"
 
-"opstooling-js@https://github.com/paritytech/opstooling-js#v0.0.14":
+"opstooling-js@https://github.com/paritytech/opstooling-js#v0.0.15":
   version "0.0.0"
-  resolved "https://github.com/paritytech/opstooling-js#de905f0bd4693087eec7b7b312e10bf95b251caf"
+  resolved "https://github.com/paritytech/opstooling-js#0c8f4c19052c7d572d9bcab6825d8c3b91035f51"
   dependencies:
     "@octokit/rest" "^18.12.0"
     async-mutex "^0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5826,9 +5826,9 @@ onetime@^5.1.2:
     prettier "^2.6.2"
     prettier-plugin-compactify "^0.1.6"
 
-"opstooling-js@https://github.com/paritytech/opstooling-js#v0.0.15":
+"opstooling-js@https://github.com/paritytech/opstooling-js#v0.0.16":
   version "0.0.0"
-  resolved "https://github.com/paritytech/opstooling-js#0c8f4c19052c7d572d9bcab6825d8c3b91035f51"
+  resolved "https://github.com/paritytech/opstooling-js#53461cd76eb48dcf72b136c5ae4aeedd320043c1"
   dependencies:
     "@octokit/rest" "^18.12.0"
     async-mutex "^0.3.2"


### PR DESCRIPTION
Related to: #132 
- made the logs more consistent 
  - the first arg (msg) always presented, as well as second (description), leave only description to see it highlevel, and then go deeper into objects/payload (msg) to see some details
  - introduced debug level, and moved some of the logs to debug, so we can filter out more noise
- Fixed the logging context
so now almost each log has connection to a 1) repo 2) PR number 3) owner etc, this way it's easier to filter only specific to the case logs, which simplifies investigations of particular events