### PR TITLE
add clean command

### DIFF
--- a/src/bot/events/onIssueCommentCreated.ts
+++ b/src/bot/events/onIssueCommentCreated.ts
@@ -45,7 +45,7 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
     return new SkipEvent(`Skipping payload because comment.user.type (${comment.user?.type}) is not "User"`)
   }
 
-  let getError = (body: string) => new PullRequestError(pr, { body, requester, requestercommentId: comment.id })
+  let getError = (body: string) => new PullRequestError(pr, { body, requester, requesterCommentId: comment.id })
 
   try {
     const commands: ParsedCommand[] = []
@@ -128,7 +128,7 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
         const commentBody = `Preparing command "${parsedCommand.command}". This comment will be updated later.`.trim()
         const createdComment = await createComment(ctx, octokit, { ...commentParams, body: commentBody })
         getError = (body: string) =>
-          new PullRequestError(pr, { body, requester, botCommentId: createdComment.id, requestercommentId: comment.id })
+          new PullRequestError(pr, { body, requester, botCommentId: createdComment.id, requesterCommentId: comment.id })
 
         const queuedDate = new Date()
 

--- a/src/bot/events/onIssueCommentCreated.ts
+++ b/src/bot/events/onIssueCommentCreated.ts
@@ -45,7 +45,7 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
     return new SkipEvent(`Skipping payload because comment.user.type (${comment.user?.type}) is not "User"`)
   }
 
-  let getError = (body: string) => new PullRequestError(pr, { body, requester, requesterCommendId: comment.id })
+  let getError = (body: string) => new PullRequestError(pr, { body, requester, requestercommentId: comment.id })
 
   try {
     const commands: ParsedCommand[] = []
@@ -128,7 +128,7 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
         const commentBody = `Preparing command "${parsedCommand.command}". This comment will be updated later.`.trim()
         const createdComment = await createComment(ctx, octokit, { ...commentParams, body: commentBody })
         getError = (body: string) =>
-          new PullRequestError(pr, { body, requester, botCommentId: createdComment.id, requesterCommendId: comment.id })
+          new PullRequestError(pr, { body, requester, botCommentId: createdComment.id, requestercommentId: comment.id })
 
         const queuedDate = new Date()
 

--- a/src/bot/events/onIssueCommentCreated.ts
+++ b/src/bot/events/onIssueCommentCreated.ts
@@ -1,20 +1,27 @@
 import { displayError, intoError } from "opstooling-js"
 import path from "path"
 
-import { CancelCommand, GenericCommand, HelpCommand, ParsedCommand } from "src/bot/parse/ParsedCommand"
+import { CancelCommand, CleanCommand, GenericCommand, HelpCommand, ParsedCommand } from "src/bot/parse/ParsedCommand"
 import { parsePullRequestBotCommandLine } from "src/bot/parse/parsePullRequestBotCommandLine"
-import { CommentData, PullRequestData, SkipEvent, WebhookHandler } from "src/bot/types"
+import { CommentData, FinishedEvent, PullRequestData, PullRequestError, SkipEvent, WebhookHandler } from "src/bot/types"
 import { getDocsUrl } from "src/command-configs/fetchCommandsConfiguration"
 import { isRequesterAllowed } from "src/core"
 import { getSortedTasks } from "src/db"
-import { createComment, getPostPullRequestResult, updateComment } from "src/github"
+import {
+  cleanComments,
+  createComment,
+  getPostPullRequestResult,
+  reactToComment,
+  removeReactionToComment,
+  updateComment,
+} from "src/github"
 import { cancelTask, getNextTaskId, PullRequestTask, queueTask, serializeTaskQueuedDate } from "src/task"
-import { PullRequestError } from "src/types"
 import { getLines } from "src/utils"
 
 export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = async (ctx, octokit, payload) => {
   const { repositoryCloneDirectory, gitlab, logger } = ctx
   const { issue, comment, repository, installation } = payload
+
   const pr: PullRequestData = { owner: repository.owner.login, repo: repository.name, number: issue.number }
   const commentParams: CommentData = { owner: pr.owner, repo: pr.repo, issue_number: pr.number }
 
@@ -38,7 +45,7 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
     return new SkipEvent(`Skipping payload because comment.user.type (${comment.user?.type}) is not "User"`)
   }
 
-  let getError = (body: string) => new PullRequestError(pr, { body, requester })
+  let getError = (body: string) => new PullRequestError(pr, { body, requester, requesterCommendId: comment.id })
 
   try {
     const commands: ParsedCommand[] = []
@@ -70,6 +77,18 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
       if (parsedCommand instanceof HelpCommand) {
         const url = getDocsUrl(parsedCommand.commitHash)
         await createComment(ctx, octokit, { ...commentParams, body: `Here's a [link to docs](${url})` })
+      }
+
+      if (parsedCommand instanceof CleanCommand) {
+        const reactionParams = { owner: pr.owner, repo: pr.repo, comment_id: comment.id }
+        const reactionId = await reactToComment(ctx, octokit, { ...reactionParams, content: "eyes" })
+        await cleanComments(ctx, octokit, { ...commentParams })
+        await Promise.all([
+          reactionId
+            ? await removeReactionToComment(ctx, octokit, { ...reactionParams, reaction_id: reactionId })
+            : null,
+          await reactToComment(ctx, octokit, { ...reactionParams, content: "+1" }),
+        ])
       }
 
       if (parsedCommand instanceof GenericCommand) {
@@ -108,7 +127,8 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
         const contributor = { owner: contributorUsername, repo: contributorRepository, branch: contributorBranch }
         const commentBody = `Preparing command "${parsedCommand.command}". This comment will be updated later.`.trim()
         const createdComment = await createComment(ctx, octokit, { ...commentParams, body: commentBody })
-        getError = (body: string) => new PullRequestError(pr, { body, requester, commentId: createdComment.id })
+        getError = (body: string) =>
+          new PullRequestError(pr, { body, requester, botCommentId: createdComment.id, requesterCommendId: comment.id })
 
         const queuedDate = new Date()
 
@@ -226,5 +246,5 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
     return getError(msg)
   }
 
-  return new SkipEvent("Reached the end of handler")
+  return new FinishedEvent(pr, comment)
 }

--- a/src/bot/parse/ParsedCommand.ts
+++ b/src/bot/parse/ParsedCommand.ts
@@ -14,6 +14,12 @@ export class CancelCommand extends ParsedCommand {
   }
 }
 
+export class CleanCommand extends ParsedCommand {
+  constructor() {
+    super("clean")
+  }
+}
+
 export class HelpCommand extends ParsedCommand {
   constructor(public commitHash: string) {
     super("help")

--- a/src/bot/parse/parsePullRequestBotCommandLine.spec.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.spec.ts
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals"
 
-import { CancelCommand, GenericCommand, HelpCommand, ParsedCommand } from "src/bot/parse/ParsedCommand"
+import { CancelCommand, CleanCommand, GenericCommand, HelpCommand, ParsedCommand } from "src/bot/parse/ParsedCommand"
 import { parsePullRequestBotCommandLine } from "src/bot/parse/parsePullRequestBotCommandLine"
 import { SkipEvent } from "src/bot/types"
 import { logger } from "src/logger"
@@ -94,6 +94,8 @@ const dataProvider: DataProvider[] = [
     Help cases
    */
   { suitName: "help", commandLine: "bot help", expectedResponse: new HelpCommand("123hash") },
+  { suitName: "help", commandLine: "bot clean", expectedResponse: new CleanCommand() },
+  { suitName: "help", commandLine: "bot clear", expectedResponse: new CleanCommand() },
 
   /*
     Cancel cases

--- a/src/bot/parse/parsePullRequestBotCommandLine.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.ts
@@ -1,7 +1,7 @@
 import assert from "assert"
 
 import { botPullRequestCommentMention, botPullRequestIgnoreCommands } from "src/bot"
-import { CancelCommand, GenericCommand, HelpCommand, ParsedCommand } from "src/bot/parse/ParsedCommand"
+import { CancelCommand, CleanCommand, GenericCommand, HelpCommand, ParsedCommand } from "src/bot/parse/ParsedCommand"
 import { parseVariables } from "src/bot/parse/parseVariables"
 import { SkipEvent } from "src/bot/types"
 import {
@@ -57,6 +57,10 @@ export const parsePullRequestBotCommandLine = async (
     }
     case "cancel": {
       return new CancelCommand(commandLine.trim())
+    }
+    case "clear":
+    case "clean": {
+      return new CleanCommand()
     }
     default: {
       const commandStartSymbol = "$ "

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -28,7 +28,7 @@ export class PullRequestError {
     public comment: {
       body: string
       botCommentId?: number
-      requesterCommendId: number
+      requestercommentId: number
       requester?: string
     },
   ) {}

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -28,7 +28,7 @@ export class PullRequestError {
     public comment: {
       body: string
       botCommentId?: number
-      requestercommentId: number
+      requesterCommentId: number
       requester?: string
     },
   ) {}

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -1,8 +1,8 @@
 import { EmitterWebhookEventName } from "@octokit/webhooks/dist-types/types"
-import { IssueCommentCreatedEvent } from "@octokit/webhooks-types"
+import { IssueComment, IssueCommentCreatedEvent } from "@octokit/webhooks-types"
 
 import { ExtendedOctokit } from "src/github"
-import { Context, PullRequestError } from "src/types"
+import { Context } from "src/types"
 
 export type PullRequestData = {
   owner: string
@@ -22,12 +22,27 @@ export type WebhookEventPayload<E extends WebhookEvents> = E extends "issue_comm
   ? IssueCommentCreatedEvent
   : never
 
+export class PullRequestError {
+  constructor(
+    public pr: PullRequestData,
+    public comment: {
+      body: string
+      botCommentId?: number
+      requesterCommendId: number
+      requester?: string
+    },
+  ) {}
+}
+
 export type WebhookHandler<E extends WebhookEvents> = (
   ctx: Context,
   octokit: ExtendedOctokit,
   event: WebhookEventPayload<E>,
-) => Promise<PullRequestError | SkipEvent>
+) => Promise<PullRequestError | SkipEvent | FinishedEvent>
 
 export class SkipEvent {
   constructor(public reason: string = "") {}
+}
+export class FinishedEvent {
+  constructor(public pr: PullRequestData, public comment: IssueComment) {}
 }

--- a/src/command-configs/renderHelpPage.pug
+++ b/src/command-configs/renderHelpPage.pug
@@ -20,7 +20,7 @@ html
               code bot command-name -v VAR=value $ argument1 argument2
             p to add new command, go to #{config.pipelineScripts.repository} and follow readme
               | to test a newly added command,
-              a(href="\#link-new-command") follow this section
+              a(href="\#link-new-command")  follow this section
 
       div.row
         div.col-3

--- a/src/command-configs/renderHelpPage.ts
+++ b/src/command-configs/renderHelpPage.ts
@@ -29,5 +29,6 @@ export function renderHelpPage(params: {
 
 // append local (or "hardcoded") commands into documentation
 function mockStaticConfig(description: string) {
-  return { command: { description } } as CmdJson
+  const config: CmdJson = { command: { description, configuration: {} } }
+  return config
 }

--- a/src/command-configs/renderHelpPage.ts
+++ b/src/command-configs/renderHelpPage.ts
@@ -4,6 +4,7 @@ import * as pug from "pug"
 import { botPullRequestCommentMention } from "src/bot"
 import { CommandConfigs } from "src/command-configs/types"
 import { Config } from "src/config"
+import { CmdJson } from "src/schema/schema.cmd"
 
 export function renderHelpPage(params: {
   config: Config
@@ -14,6 +15,9 @@ export function renderHelpPage(params: {
   const tmplPath = path.join(__dirname, "renderHelpPage.pug")
   const { commandConfigs, scriptsRevision, headBranch, config } = params
 
+  commandConfigs.help = mockStaticConfig("Generates help page & provides a link")
+  commandConfigs.clean = mockStaticConfig("Clears bot comments in PR")
+
   const repoLink = new URL(path.join(config.pipelineScripts.repository, "tree", headBranch)).toString()
   const commandStart = botPullRequestCommentMention
 
@@ -21,4 +25,9 @@ export function renderHelpPage(params: {
           same for PATCH_repo=xxx
      TODO: Simplify the PIPELINE_SCRIPTS_REF to something more rememberable */
   return pug.renderFile(tmplPath, { config, repoLink, commandConfigs, scriptsRevision, headBranch, commandStart })
+}
+
+// append local (or "hardcoded") commands into documentation
+function mockStaticConfig(description: string) {
+  return { command: { description } } as CmdJson
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,21 +40,6 @@ export type Context = {
   }
 }
 
-export class PullRequestError {
-  constructor(
-    public pr: {
-      owner: string
-      repo: string
-      number: number
-    },
-    public comment: {
-      body: string
-      commentId?: number
-      requester?: string
-    },
-  ) {}
-}
-
 export type ToString = { toString: () => string }
 
 export type CommandOutput = Error | string

--- a/test/github-non-pipeline-cases.spec.ts
+++ b/test/github-non-pipeline-cases.spec.ts
@@ -27,7 +27,9 @@ type CommandDataProviderItem = {
   suitName: string
   commandLine: string
   expected: {
-    startMessage: string
+    startMessage?: string
+    startReaction?: string
+    finishReaction?: string
   }
 }
 const commandsDataProvider: CommandDataProviderItem[] = [
@@ -41,7 +43,7 @@ const commandsDataProvider: CommandDataProviderItem[] = [
     commandLine: "bot hrlp", // intentional typo
     expected: {
       startMessage:
-        '@somedev123 Could not find matching configuration for command "hrlp"; Available ones are bench, fmt, sample, try-runtime. Refer to [help docs](http://localhost:3000/static/docs/',
+        '@somedev123 Could not find matching configuration for command "hrlp"; Available ones are bench, fmt, sample, try-runtime, help, clean. Refer to [help docs](http://localhost:3000/static/docs/',
     },
   },
   {
@@ -49,6 +51,15 @@ const commandsDataProvider: CommandDataProviderItem[] = [
     commandLine: "bot cancel",
     expected: { startMessage: "@somedev123 No task is being executed for this pull request" },
   },
+  // TODO: add test for clean after moving to opstooling-testing
+  // {
+  //   suitName: "[clean] command",
+  //   commandLine: "bot clean",
+  //   expected: {
+  //     startReaction: "eyes",
+  //     finishReaction: "+1"
+  //   },
+  // },
 ]
 
 beforeAll(async () => {


### PR DESCRIPTION
Fixes: #158 
`bot clean` with 👀 and 👍 reaction on start and finish accordingly, cuz it could take time to do that, and it needs to be "responsive" and more transparent of what is going on.
I was trying to set "common" way to react on commands, but whole PR looked over😵‍💫smiled, so keeping only for `bot clean`  where it makes more sense

![image](https://user-images.githubusercontent.com/1177472/214880393-f0b939dd-0de1-48ce-b934-f5a62fda1a04.png)
