### PR TITLE
enhanced args validation making it optional per preset

### DIFF
--- a/src/bot/events/onIssueCommentCreated.ts
+++ b/src/bot/events/onIssueCommentCreated.ts
@@ -57,7 +57,7 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
   try {
     const commands: ParsedCommand[] = [];
     for (const line of getLines(comment.body)) {
-      const parsedCommand = await parsePullRequestBotCommandLine(line, ctx);
+      const parsedCommand = await parsePullRequestBotCommandLine(line, ctx, pr.repo);
 
       if (parsedCommand instanceof SkipEvent) {
         return parsedCommand;

--- a/src/bot/parse/isOptionalArgsCommand.spec.ts
+++ b/src/bot/parse/isOptionalArgsCommand.spec.ts
@@ -1,0 +1,69 @@
+import { isOptionalArgsCommand } from "src/bot/parse/isOptionalArgsCommand";
+import { CmdJson } from "src/schema/schema.cmd";
+
+type DataProvider = {
+  suitName: string;
+  presets: CmdJson;
+  isOptional: boolean;
+};
+
+function stubPresets(presets: CmdJson["command"]["presets"]): CmdJson {
+  return { command: { configuration: { gitlab: { job: { tags: [""] } } }, presets: { ...presets } } };
+}
+
+const dataProvider: DataProvider[] = [
+  { suitName: "test that command args are optional without presets", presets: stubPresets({}), isOptional: true },
+  {
+    suitName: "test that command args are required with presets and args",
+    presets: stubPresets({ common: { description: "common", args: { arg1: { label: "1" } } } }),
+    isOptional: false,
+  },
+  {
+    suitName: "test that command args are optional with presets but no args",
+    presets: stubPresets({ common: { description: "common" } }),
+    isOptional: true,
+  },
+  {
+    suitName: "test that command args are optional with polkadot repo presets but no args",
+    presets: stubPresets({
+      polkadot: { description: "polkadot", repos: ["polkadot"] },
+      substrate: { description: "substrate", repos: ["substrate"], args: { arg1: { label: "1" } } },
+    }),
+    isOptional: true,
+  },
+  {
+    suitName: "test that command args are required with polkadot repo presets and args",
+    presets: stubPresets({
+      polkadot: { description: "polkadot", repos: ["polkadot"], args: { arg1: { label: "1" } } },
+      substrate: { description: "substrate", repos: ["substrate"], args: { arg1: { label: "1" } } },
+    }),
+    isOptional: false,
+  },
+  {
+    suitName: "test that command args are required with different polkadot presets where all have args defined",
+    presets: stubPresets({
+      polkadot1: { description: "polkadot-1", repos: ["polkadot"], args: { arg1: { label: "1" } } },
+      polkadot2: { description: "polkadot-2", repos: ["polkadot"], args: { arg1: { label: "1" } } },
+      substrate: { description: "substrate", repos: ["substrate"], args: { arg1: { label: "1" } } },
+    }),
+    isOptional: false,
+  },
+  {
+    suitName:
+      "test that command args are optional with different polkadot presets where at least one has no args defined",
+    presets: stubPresets({
+      polkadot1: { description: "polkadot-1", repos: ["polkadot"] },
+      polkadot2: { description: "polkadot-2", repos: ["polkadot"], args: { arg1: { label: "1" } } },
+      substrate: { description: "substrate", repos: ["substrate"], args: { arg1: { label: "1" } } },
+    }),
+    isOptional: true,
+  },
+];
+
+describe("isOptionalArgsPreset", () => {
+  for (const { suitName, presets, isOptional } of dataProvider) {
+    test(`test commandLine: [${suitName}]`, () => {
+      expect(isOptionalArgsCommand(presets, "cmd", "polkadot")).toEqual(isOptional);
+    });
+  }
+});

--- a/src/bot/parse/isOptionalArgsCommand.spec.ts
+++ b/src/bot/parse/isOptionalArgsCommand.spec.ts
@@ -66,4 +66,14 @@ describe("isOptionalArgsPreset", () => {
       expect(isOptionalArgsCommand(presets, "cmd", "polkadot")).toEqual(isOptional);
     });
   }
+
+  test("test throws error if no presets found for repo", () => {
+    expect(() =>
+      isOptionalArgsCommand(
+        stubPresets({ substrate: { description: "substrate", repos: ["substrate"], args: { arg1: { label: "1" } } } }),
+        "cmd",
+        "polkadot",
+      ),
+    ).toThrow('The command: "cmd" is not supported in **polkadot** repository');
+  });
 });

--- a/src/bot/parse/isOptionalArgsCommand.ts
+++ b/src/bot/parse/isOptionalArgsCommand.ts
@@ -26,7 +26,7 @@ export function isOptionalArgsCommand(cfg: CmdJson, command: string, repo: strin
 
     // if no presets found -> return error that such command is not applicable to this repo
     if (repoPresets.length === 0) {
-      throw new Error(`The command: "${command}" is not supported in **${repo}** repository; Check out \`bot help\``);
+      throw new Error(`The command: "${command}" is not supported in **${repo}** repository`);
     } else if (repoPresets.length === 1) {
       const hasArgsDefined = repoPresets.some((preset) => Object.keys(preset.args || {}).length > 0);
       // If one preset with current repo is presented ->

--- a/src/bot/parse/isOptionalArgsCommand.ts
+++ b/src/bot/parse/isOptionalArgsCommand.ts
@@ -1,0 +1,50 @@
+import { CmdJson } from "src/schema/schema.cmd";
+
+// details: https://github.com/paritytech/command-bot/issues/171
+export function isOptionalArgsCommand(cfg: CmdJson, command: string, repo: string): boolean {
+  const presets = cfg?.command?.presets || {};
+  const hasAnyPresets = Object.keys(presets)?.length > 0;
+
+  if (!hasAnyPresets) {
+    return true;
+  }
+
+  // presets with unspecified repos, means they could be used in all repos.
+  // Like `bot help`
+  const commonPresets = Object.values(presets).filter((preset) => !preset.repos || preset.repos.length === 0);
+
+  // if there are presets for all repos: use them as a validation of args presence
+  if (commonPresets.length > 0) {
+    const hasArgsDefined = commonPresets.some((preset) => Object.keys(preset.args || {}).length > 0);
+
+    if (!hasArgsDefined) {
+      return true;
+    }
+  } else {
+    // pick the presets by the current repo
+    const repoPresets = Object.values(presets).filter((preset) => preset.repos?.includes(repo));
+
+    // if no presets found -> return error that such command is not applicable to this repo
+    if (repoPresets.length === 0) {
+      throw new Error(`The command: "${command}" is not supported in **${repo}** repository; Check out \`bot help\``);
+    } else if (repoPresets.length === 1) {
+      const hasArgsDefined = repoPresets.some((preset) => Object.keys(preset.args || {}).length > 0);
+      // If one preset with current repo is presented ->
+      // see if this preset has args specified - expect command to provide args, otherwise - expect not
+      if (!hasArgsDefined) {
+        return true;
+      }
+    } else {
+      // if more then one presets has found ->
+      // see if all have args -> then args are required,
+      // if at least one doesn't have args -> optional
+      const everyPresetHasArgsDefined = repoPresets.every((preset) => Object.keys(preset.args || {}).length > 0);
+
+      if (!everyPresetHasArgsDefined) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/src/bot/parse/parsePullRequestBotCommandLine.spec.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.spec.ts
@@ -148,7 +148,7 @@ const dataProvider: DataProvider[] = [
 describe("parsePullRequestBotCommandLine", () => {
   for (const { suitName, commandLine, expectedResponse } of dataProvider) {
     test(`test commandLine: ${commandLine} [${suitName}]`, async () => {
-      const res = await parsePullRequestBotCommandLine(commandLine, { logger });
+      const res = await parsePullRequestBotCommandLine(commandLine, { logger }, "polkadot");
       expect(res).toEqual(expectedResponse);
     });
   }

--- a/src/bot/parse/parsePullRequestBotCommandLine.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 
 import { botPullRequestCommentMention, botPullRequestIgnoreCommands } from "src/bot";
+import { isOptionalArgsCommand } from "src/bot/parse/isOptionalArgsCommand";
 import { CancelCommand, CleanCommand, GenericCommand, HelpCommand, ParsedCommand } from "src/bot/parse/ParsedCommand";
 import { parseVariables } from "src/bot/parse/parseVariables";
 import { SkipEvent } from "src/bot/types";
@@ -16,6 +17,7 @@ import { validateSingleShellCommand } from "src/shell";
 export const parsePullRequestBotCommandLine = async (
   rawCommandLine: string,
   ctx: LoggerContext,
+  repo: string,
 ): Promise<SkipEvent | Error | ParsedCommand> => {
   let commandLine = rawCommandLine.trim();
 
@@ -87,7 +89,7 @@ export const parsePullRequestBotCommandLine = async (
       }
 
       // if presets has nothing - then it means that the command doesn't need any arguments and runs as is
-      if (Object.keys(commandConfigs[subcommand]?.command?.presets || [])?.length === 0) {
+      if (isOptionalArgsCommand(commandConfigs[subcommand], subcommand, repo)) {
         configuration.optionalCommandArgs = true;
       }
 

--- a/src/bot/parse/parsePullRequestBotCommandLine.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.ts
@@ -88,9 +88,16 @@ export const parsePullRequestBotCommandLine = async (
         );
       }
 
-      // if presets has nothing - then it means that the command doesn't need any arguments and runs as is
-      if (isOptionalArgsCommand(commandConfigs[subcommand], subcommand, repo)) {
-        configuration.optionalCommandArgs = true;
+      try {
+        // if presets has nothing - then it means that the command doesn't need any arguments and runs as is
+        if (isOptionalArgsCommand(commandConfigs[subcommand], subcommand, repo)) {
+          configuration.optionalCommandArgs = true;
+        }
+      } catch (e) {
+        if (e instanceof Error) {
+          return new Error(`${e.message}. ${helpStr}`);
+        }
+        throw e;
       }
 
       if (!commandLinePart && configuration.optionalCommandArgs !== true) {

--- a/src/bot/parse/parsePullRequestBotCommandLine.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.ts
@@ -89,7 +89,6 @@ export const parsePullRequestBotCommandLine = async (
       }
 
       try {
-        // if presets has nothing - then it means that the command doesn't need any arguments and runs as is
         if (isOptionalArgsCommand(commandConfigs[subcommand], subcommand, repo)) {
           configuration.optionalCommandArgs = true;
         }

--- a/src/test/github-non-pipeline-cases.spec.ts
+++ b/src/test/github-non-pipeline-cases.spec.ts
@@ -47,6 +47,14 @@ const commandsDataProvider: CommandDataProviderItem[] = [
     },
   },
   {
+    suitName: "[not allowed] command",
+    commandLine: "bot bench-all", // command-bot-test repo is not in a list of repos: [...] array
+    expected: {
+      startMessage:
+        '@somedev123 The command: "bench-all" is not supported in **command-bot-test** repository. Refer to [help docs](http://localhost:3000/static/docs/',
+    },
+  },
+  {
     suitName: "[cancel] command for no jobs",
     commandLine: "bot cancel",
     expected: { startMessage: "@somedev123 No task is being executed for this pull request" },


### PR DESCRIPTION
Closes #171 

Testing: 
- https://github.com/mak-parity-org2/substrate/pull/1 `bot bench-all` has no args
![image](https://user-images.githubusercontent.com/1177472/222583879-0da0cdd7-a334-4f4b-b858-edf9dfd6e8c9.png)


- https://github.com/mak-parity-org2/polkadot/pull/1 `bot bench-all` requires ` $ polkadot` or other network
 
![image](https://user-images.githubusercontent.com/1177472/222583958-d4089859-2ad5-47ef-af9b-e2ec69764de2.png)


Also added check for repository, so you can't run wrong command in wrong repo, like [sample](https://github.com/paritytech/command-bot-scripts/blob/main/commands/sample/sample.cmd.json#L16) is polkadot only, and if you run it in scope of substrate you'll get this error 
![image](https://user-images.githubusercontent.com/1177472/222583027-e4aa9b7b-f7bd-4e0b-9c6e-6e10408c810d.png)
