### PR TITLE
Add CI job to publish docker image description to hub.docker.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,6 +105,22 @@ build-push-docker-app:
   after_script:
     - buildah logout --all
 
+push-docker-image-description:
+  stage:                           build
+  variables:
+    CI_IMAGE:                      paritytech/dockerhub-description
+    DOCKERHUB_REPOSITORY:          paritytech/command-bot
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
+    SHORT_DESCRIPTION:             "command-bot provides interfaces for executing arbitrary commands on GitLab CI"
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      changes:
+      - Dockerfile.README.md
+  script:
+    - cd / && sh entrypoint.sh
+
 #### App deployment
 
 .deploy-k8s:                       &deploy-k8s

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -1,0 +1,3 @@
+# command-bot
+
+## [GitHub](https://github.com/paritytech/command-bot)


### PR DESCRIPTION
Added CI job to publish Docker image description to [hub.docker.com](https://hub.docker.com/r/paritytech/command-bot)
Description can be updated in a `Dockerfile.README.md` file in a repository root and as soon it will be merged into the `master` branch, its content will get published to [hub.docker.com](https://hub.docker.com/r/paritytech/command-bot)

Related https://github.com/paritytech/ci_cd/issues/741