### PR TITLE
Mak/164 symlink to latest

### DIFF
--- a/src/bot/events/onIssueCommentCreated.ts
+++ b/src/bot/events/onIssueCommentCreated.ts
@@ -11,7 +11,6 @@ import {
   SkipEvent,
   WebhookHandler,
 } from "src/bot/types";
-import { getDocsUrl } from "src/command-configs/fetchCommandsConfiguration";
 import { isRequesterAllowed } from "src/core";
 import { getSortedTasks } from "src/db";
 import {
@@ -82,8 +81,10 @@ export const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = as
       logger.debug({ parsedCommand }, "Processing parsed command");
 
       if (parsedCommand instanceof HelpCommand) {
-        const url = getDocsUrl(parsedCommand.commitHash);
-        await createComment(ctx, octokit, { ...commentParams, body: `Here's a [link to docs](${url})` });
+        await createComment(ctx, octokit, {
+          ...commentParams,
+          body: `Here's a [link to docs](${parsedCommand.docsPath})`,
+        });
       }
 
       if (parsedCommand instanceof CleanCommand) {

--- a/src/bot/parse/ParsedCommand.ts
+++ b/src/bot/parse/ParsedCommand.ts
@@ -21,7 +21,7 @@ export class CleanCommand extends ParsedCommand {
 }
 
 export class HelpCommand extends ParsedCommand {
-  constructor(public commitHash: string) {
+  constructor(public docsPath: string) {
     super("help");
   }
 }

--- a/src/bot/parse/parsePullRequestBotCommandLine.spec.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.spec.ts
@@ -86,14 +86,18 @@ const dataProvider: DataProvider[] = [
     suitName: "bench-bot, no args when not allowed, should return error",
     commandLine: "bot bench",
     expectedResponse: new Error(
-      `Missing arguments for command "bench". Refer to [help docs](http://cmd-bot.docs.com/) and/or [source code](https://github.com/paritytech/command-bot-scripts).`,
+      `Missing arguments for command "bench". Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).`,
     ),
   },
 
   /*
     Help cases
    */
-  { suitName: "help", commandLine: "bot help", expectedResponse: new HelpCommand("123hash") },
+  {
+    suitName: "help",
+    commandLine: "bot help",
+    expectedResponse: new HelpCommand("http://cmd-bot.docs.com/static/docs/latest.html"),
+  },
   { suitName: "help", commandLine: "bot clean", expectedResponse: new CleanCommand() },
   { suitName: "help", commandLine: "bot clear", expectedResponse: new CleanCommand() },
 
@@ -126,21 +130,21 @@ const dataProvider: DataProvider[] = [
     suitName: "nonexistent command, should return proper error",
     commandLine: "bot nope 123123",
     expectedResponse: new Error(
-      'Unknown command "nope"; Available ones are bench, fmt, sample, try-runtime. Refer to [help docs](http://cmd-bot.docs.com/) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
+      'Unknown command "nope"; Available ones are bench, fmt, sample, try-runtime. Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     ),
   },
   {
     suitName: "not provided command, returns proper error",
     commandLine: "bot $",
     expectedResponse: new Error(
-      'Unknown command "$"; Available ones are bench, fmt, sample, try-runtime. Refer to [help docs](http://cmd-bot.docs.com/) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
+      'Unknown command "$"; Available ones are bench, fmt, sample, try-runtime. Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     ),
   },
   {
     suitName: "non existed config must return error with explanation",
     commandLine: "bot xz",
     expectedResponse: new Error(
-      `Unknown command "xz"; Available ones are bench, fmt, sample, try-runtime. Refer to [help docs](http://cmd-bot.docs.com/) and/or [source code](https://github.com/paritytech/command-bot-scripts).`,
+      `Unknown command "xz"; Available ones are bench, fmt, sample, try-runtime. Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).`,
     ),
   },
 ];

--- a/src/bot/parse/parsePullRequestBotCommandLine.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.ts
@@ -5,11 +5,7 @@ import { isOptionalArgsCommand } from "src/bot/parse/isOptionalArgsCommand";
 import { CancelCommand, CleanCommand, GenericCommand, HelpCommand, ParsedCommand } from "src/bot/parse/ParsedCommand";
 import { parseVariables } from "src/bot/parse/parseVariables";
 import { SkipEvent } from "src/bot/types";
-import {
-  fetchCommandsConfiguration,
-  getDocsUrl,
-  PIPELINE_SCRIPTS_REF,
-} from "src/command-configs/fetchCommandsConfiguration";
+import { fetchCommandsConfiguration, PIPELINE_SCRIPTS_REF } from "src/command-configs/fetchCommandsConfiguration";
 import { config } from "src/config";
 import { LoggerContext } from "src/logger";
 import { validateSingleShellCommand } from "src/shell";
@@ -51,12 +47,9 @@ export const parsePullRequestBotCommandLine = async (
         return variables;
       }
 
-      const { commitHash: commandsConfigsCommitHash } = await fetchCommandsConfiguration(
-        ctx,
-        variables[PIPELINE_SCRIPTS_REF],
-      );
+      const { docsPath } = await fetchCommandsConfiguration(ctx, variables[PIPELINE_SCRIPTS_REF]);
 
-      return new HelpCommand(commandsConfigsCommitHash);
+      return new HelpCommand(docsPath);
     }
     case "cancel": {
       return new CancelCommand(commandLine.trim());
@@ -75,12 +68,10 @@ export const parsePullRequestBotCommandLine = async (
         return variables;
       }
 
-      const { commandConfigs, commitHash } = await fetchCommandsConfiguration(ctx, variables[PIPELINE_SCRIPTS_REF]);
+      const { commandConfigs, docsPath } = await fetchCommandsConfiguration(ctx, variables[PIPELINE_SCRIPTS_REF]);
       const configuration = commandConfigs[subcommand]?.command?.configuration;
 
-      const helpStr = `Refer to [help docs](${getDocsUrl(commitHash)}) and/or [source code](${
-        config.pipelineScripts.repository
-      }).`;
+      const helpStr = `Refer to [help docs](${docsPath}) and/or [source code](${config.pipelineScripts.repository}).`;
 
       if (typeof configuration === "undefined" || !Object.keys(configuration).length) {
         return new Error(

--- a/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
+++ b/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
@@ -155,7 +155,5 @@ export const cmd: CommandConfigs = {
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const fetchCommandsConfiguration = jest.fn<() => Promise<FetchCommandConfigsResult>>(async () => {
-  return { commandConfigs: cmd, commitHash: "123hash" };
+  return { commandConfigs: cmd, docsPath: "http://cmd-bot.docs.com/static/docs/latest.html" };
 });
-// eslint-disable-next-line @typescript-eslint/require-await
-export const getDocsUrl = jest.fn<() => string>(() => "http://cmd-bot.docs.com/");

--- a/src/command-configs/fetchCommandsConfiguration.ts
+++ b/src/command-configs/fetchCommandsConfiguration.ts
@@ -13,7 +13,7 @@ import { DOCS_DIR, DOCS_URL_PATH, GENERATED_DIR } from "src/setup";
 import { CommandRunner } from "src/shell";
 
 export const PIPELINE_SCRIPTS_REF = "PIPELINE_SCRIPTS_REF";
-const LATEST = "latest";
+export const LATEST = "latest";
 
 export async function fetchCommandsConfiguration(
   ctx: LoggerContext,
@@ -66,6 +66,6 @@ function getDocsUrl(filename: string): string {
   return new URL(path.join(config.cmdBotUrl, DOCS_URL_PATH, getDocsFilename(filename))).toString();
 }
 
-function getDocsFilename(scriptsRevision: string): string {
+export function getDocsFilename(scriptsRevision: string): string {
   return `${scriptsRevision}.html`;
 }

--- a/src/command-configs/types.ts
+++ b/src/command-configs/types.ts
@@ -2,4 +2,4 @@ import { CmdJson } from "src/schema/schema.cmd";
 
 export type CommandConfigs = { [key: string]: CmdJson };
 
-export type FetchCommandConfigsResult = { commandConfigs: CommandConfigs; commitHash: string };
+export type FetchCommandConfigsResult = { commandConfigs: CommandConfigs; docsPath: string };

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,7 +7,7 @@ import { Probot, Server } from "probot";
 
 import { setupApi } from "src/api";
 import { setupBot } from "src/bot";
-import { fetchCommandsConfiguration } from "src/command-configs/fetchCommandsConfiguration";
+import { fetchCommandsConfiguration, getDocsFilename, LATEST } from "src/command-configs/fetchCommandsConfiguration";
 import { config } from "src/config";
 import { AccessDB, getDb, getSortedTasks, TaskDB } from "src/db";
 import { logger } from "src/logger";
@@ -37,7 +37,7 @@ export const setup = async (
   await ensureDir(DOCS_DIR);
   server.expressApp.use(DOCS_URL_PATH, express.static(DOCS_DIR));
   server.expressApp.get("/", (req, res) => {
-    res.redirect(path.join(DOCS_URL_PATH, "latest.html"), 301);
+    res.redirect(path.join(DOCS_URL_PATH, getDocsFilename(LATEST)), 301);
   });
 
   const taskDbPath = path.join(dataPath, "db");

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,6 +7,7 @@ import { Probot, Server } from "probot";
 
 import { setupApi } from "src/api";
 import { setupBot } from "src/bot";
+import { fetchCommandsConfiguration } from "src/command-configs/fetchCommandsConfiguration";
 import { config } from "src/config";
 import { AccessDB, getDb, getSortedTasks, TaskDB } from "src/db";
 import { logger } from "src/logger";
@@ -35,6 +36,9 @@ export const setup = async (
 
   await ensureDir(DOCS_DIR);
   server.expressApp.use(DOCS_URL_PATH, express.static(DOCS_DIR));
+  server.expressApp.get("/", (req, res) => {
+    res.redirect(path.join(DOCS_URL_PATH, "latest.html"), 301);
+  });
 
   const taskDbPath = path.join(dataPath, "db");
   await initDatabaseDir(taskDbPath);
@@ -123,6 +127,9 @@ export const setup = async (
   void requeueUnterminatedTasks(ctx, bot);
 
   setupBot(ctx, bot);
-
   setupApi(ctx, server);
+
+  // if we re-deploy server, the "generated" folder will be wiped,
+  // so we need to pre-fetch commands, so the documentation is available right away
+  await fetchCommandsConfiguration(ctx);
 };

--- a/src/test/github-non-pipeline-cases.spec.ts
+++ b/src/test/github-non-pipeline-cases.spec.ts
@@ -36,14 +36,22 @@ const commandsDataProvider: CommandDataProviderItem[] = [
   {
     suitName: "[help] command",
     commandLine: "bot help",
-    expected: { startMessage: "Here's a [link to docs](http://localhost:3000/static/docs/" },
+    expected: { startMessage: "Here's a [link to docs](http://localhost:3000/static/docs/latest.html" },
+  },
+  {
+    suitName: "[help] command with branch override",
+    commandLine: "bot help -v PIPELINE_SCRIPTS_REF=tests",
+    expected: {
+      startMessage:
+        "Here's a [link to docs](http://localhost:3000/static/docs/1245345a4376f18f3ef98195055876ff293f8622.html",
+    },
   },
   {
     suitName: "[wrong] command",
     commandLine: "bot hrlp", // intentional typo
     expected: {
       startMessage:
-        '@somedev123 Unknown command "hrlp"; Available ones are bench-all, bench-vm, bench, fmt, merge, rebase, sample, try-runtime. Refer to [help docs](http://localhost:3000/static/docs/',
+        '@somedev123 Unknown command "hrlp"; Available ones are bench-all, bench-vm, bench, fmt, merge, rebase, sample, try-runtime. Refer to [help docs](http://localhost:3000/static/docs/latest.html ) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     },
   },
   {
@@ -51,7 +59,7 @@ const commandsDataProvider: CommandDataProviderItem[] = [
     commandLine: "bot bench-all", // command-bot-test repo is not in a list of repos: [...] array
     expected: {
       startMessage:
-        '@somedev123 The command: "bench-all" is not supported in **command-bot-test** repository. Refer to [help docs](http://localhost:3000/static/docs/',
+        '@somedev123 The command: "bench-all" is not supported in **command-bot-test** repository. Refer to [help docs](http://localhost:3000/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     },
   },
   {

--- a/src/test/github-non-pipeline-cases.spec.ts
+++ b/src/test/github-non-pipeline-cases.spec.ts
@@ -51,7 +51,7 @@ const commandsDataProvider: CommandDataProviderItem[] = [
     commandLine: "bot hrlp", // intentional typo
     expected: {
       startMessage:
-        '@somedev123 Unknown command "hrlp"; Available ones are bench-all, bench-vm, bench, fmt, merge, rebase, sample, try-runtime. Refer to [help docs](http://localhost:3000/static/docs/latest.html ) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
+        '@somedev123 Unknown command "hrlp"; Available ones are bench-all, bench-vm, bench, fmt, merge, rebase, sample, try-runtime. Refer to [help docs](http://localhost:3000/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     },
   },
   {


### PR DESCRIPTION
Closes https://github.com/paritytech/command-bot/issues/164
- reduced spread of getDocsUrl logic (as nothing else needs a commit hash but docs)
- added few tests to cover master and dev-branch revisions to make sure that detault link goes to /static/docs/latest.html
- generate docs straight on server start, since the **generated** folder is removed every re-deploy, so making sure that the latest.html is always exist (not only after running command explicitly)
- and actually create a symlink to a file with commit which generated from master (non overridden dev branch)

tests: https://github.com/mak-parity-org2/substrate/pull/1#issuecomment-1482031527