### PR TITLE
wrap pipeline query into retriable

### DIFF
--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,36 @@
+import { retriable } from "src/utils";
+
+describe("retriable", () => {
+  const wrapRetriable = async (fakeRetryCount: number) =>
+    await retriable(
+      async () =>
+        await new Promise((resolve, reject) => {
+          if (fakeRetryCount > 0) {
+            fakeRetryCount--;
+            reject(0);
+          } else {
+            resolve(1);
+          }
+        }),
+      { timeoutMs: 100, attempts: 3 },
+    );
+
+  test("resolve after 1/3 times", async () => {
+    const res = await wrapRetriable(1);
+    expect(res).toBe(1);
+  });
+
+  test("resolve after 2/3 times", async () => {
+    const res = await wrapRetriable(2);
+
+    expect(res).toBe(1);
+  });
+
+  test("reject after 3/3 times", async () => {
+    try {
+      await wrapRetriable(3);
+    } catch (e) {
+      expect(e).toEqual(0);
+    }
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,3 +110,32 @@ export const arrayify = <T>(value: undefined | null | T | T[]): T[] => {
   }
   return [value];
 };
+
+export type RetriableConfig = {
+  attempts: number;
+  timeoutMs: number;
+};
+
+/** @throws Error */
+export const retriable = async <T>(
+  callback: () => Promise<T>,
+  options: RetriableConfig = { attempts: 3, timeoutMs: 2000 },
+): Promise<T> => {
+  let { attempts } = options;
+  const { timeoutMs } = options;
+
+  for (attempts; attempts > 0; attempts--) {
+    try {
+      return await callback();
+    } catch (e) {
+      await millisecondsDelay(timeoutMs);
+
+      // last failed attempt
+      if (attempts === 1) {
+        throw e;
+      }
+    }
+  }
+
+  throw Error(`Couldn't resolve a promise after ${options.attempts} attempts with ${options.timeoutMs}ms timeout`);
+};


### PR DESCRIPTION
Closes https://github.com/paritytech/command-bot/issues/166
the issue was the fact that when we push a .gitlab-ci.yml with a command script, it tried to get a pipeline very soon after a push. The problem doesn't reproduce on small repositories, only on prod on huge repos, when the pipeline starts with slight more delay. So 
1st. - move the preventive delay right before the pipeline + 
2nd. - wrap pipeline query into retriable 