### PR TITLE
[ci] Increase deploy timeout

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,7 +141,7 @@ push-docker-image-description:
     - helm secrets upgrade
       --install
       --atomic
-      --timeout 300s
+      --timeout 600s
       --namespace ${CI_PROJECT_NAME}
       --values helm/values.yaml
       --values helm/values-$ENVIRONMENT.yaml


### PR DESCRIPTION
Last deploy 300s [were not enough ](https://gitlab.parity.io/parity/mirrors/command-bot/-/jobs/2667847) (it took too long to download the image to host). PR increases timeout