### PR TITLE
Update values-parity-stg.yaml

### DIFF
--- a/helm/values-parity-stg.yaml
+++ b/helm/values-parity-stg.yaml
@@ -25,7 +25,7 @@ common:
     DB_PORT: 5432
     CMD_BOT_URL: https://command-bot.parity-stg.parity.io/
     PIPELINE_SCRIPTS_REF: monorepo
-    BOT_PR_COMMENT_MENTION: stgbot
+    BOT_PR_COMMENT_MENTION: bot
   secrets:
     ALLOWED_ORGANIZATIONS: ref+vault://kv/gitlab/parity/mirrors/command-bot/devops-parity-stg#ALLOWED_ORGANIZATIONS
     APP_ID: ref+vault://kv/gitlab/parity/mirrors/command-bot/devops-parity-stg#APP_ID

--- a/src/command-configs/help/parts/hero.pug
+++ b/src/command-configs/help/parts/hero.pug
@@ -9,11 +9,19 @@ div.ms-hero.mb-lg
       p running custom commands, like:
         br
         code #{commandStart} command-name -v VAR=value id --argument=1 --argument=2
-      p to add new command:
+        br
+        | Or even multiple commands in one comment:
+        br
+        code #{commandStart} clean
+        br
+        code #{commandStart} command-name --argument=2
+        br
+        code #{commandStart} command-name --argument=3
+      p To add new command: &nbsp;
         ul
           li go to
             a(href=config.pipelineScripts.repository) #{config.pipelineScripts.repository}
           li add new command and open PR
-          li read
+          li read &nbsp;
             a(href="\#link-new-command") how to test new command before merging
           li merge. Then after merge PR, it accessible without branch override


### PR DESCRIPTION
it's not needed to differentiate the `stgbot` from `bot` as the are anyway isolated (paritytech-stg/polkadot vs paritytech/polkadot).
It's more actual for `localbot`s which may be tested against repos, where `bot` will also be triggered