### PR TITLE
Use labels for repos in the help page

### DIFF
--- a/src/command-configs/help/parts/commands_preset.pug
+++ b/src/command-configs/help/parts/commands_preset.pug
@@ -1,6 +1,9 @@
 div(class="preset " + preset.repos.join(' '))
   h6.mb-md(id="link-"+presetId) #{commandStart} #{ commandName } #{presetId === 'default' ? '' : presetId}
-  p.mb-md.muted Works in these repos: [#{preset.repos.join(', ')}]
+  p.mb-md.muted
+    | Works in these repos:&nbsp;
+    each repo in preset.repos
+      span.ms-label #{repo}
   -let defaultArgs = []
   if preset.args && Object.values(preset.args).length > 0
     div.preset-args.mb-lg.ml-md


### PR DESCRIPTION
<img width="486" alt="Screenshot 2023-07-18 at 19 46 55" src="https://github.com/paritytech/command-bot/assets/12039224/d3de5287-83d5-48fb-b0bb-6e5da2f391bc">
