### PR TITLE
Mak fix docs

### DIFF
--- a/src/command-configs/help/parts/commands_preset.pug
+++ b/src/command-configs/help/parts/commands_preset.pug
@@ -1,5 +1,5 @@
 div(class="preset " + preset.repos.join(' '))
-  h6.mb-md(id="link-"+presetId) #{commandStart} #{ commandName } #{presetId === 'default' ? '' : presetId}
+  h6.mb-md(id="link-"+ commandName + "-" + presetId) #{commandStart} #{ commandName } #{presetId === 'default' ? '' : presetId}
   p.mb-md.muted
     | Works in these repos:&nbsp;
     each repo in preset.repos

--- a/src/command-configs/help/parts/navigation.pug
+++ b/src/command-configs/help/parts/navigation.pug
@@ -13,7 +13,7 @@ div.sticky-nav
           ul.nav-preset
             each preset, presetId in cfg.command.presets
               li(class="preset-link " + preset.repos.join(' '))
-                a(href="\#link-" + presetId) #{ presetId }
+                a(href="\#link-" + commandName + "-" + presetId) #{ presetId }
   | Env Variables
   ul
     li

--- a/src/command-configs/help/parts/navigation.pug
+++ b/src/command-configs/help/parts/navigation.pug
@@ -12,8 +12,9 @@ div.sticky-nav
         if cfg.command.presets
           ul.nav-preset
             each preset, presetId in cfg.command.presets
-              li(class="preset-link " + preset.repos.join(' '))
-                a(href="\#link-" + commandName + "-" + presetId) #{ presetId }
+              if presetId !== 'default'
+                li(class="preset-link " + preset.repos.join(' '))
+                  a(href="\#link-" + commandName + "-" + presetId) #{ presetId }
   | Env Variables
   ul
     li


### PR DESCRIPTION
- Fix #231 
- Remove default from the nav list, as root command link anyway leads to the same place