### PR TITLE
Add argument & command validation in scope of repo

### DIFF
--- a/src/bot/parse/parsePullRequestBotCommandLine.spec.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.spec.ts
@@ -34,7 +34,7 @@ const dataProvider: DataProvider[] = [
       "bench",
       {
         commandStart: ['"$PIPELINE_SCRIPTS_DIR/commands/bench/bench.sh"'],
-        gitlab: { job: { tags: ["bench-bot"], variables: {} } },
+        gitlab: { job: { tags: ["weights-vm"], variables: {} } },
       },
       { PIPELINE_SCRIPTS_REF: "hello-is-this-even-used" },
       '"$PIPELINE_SCRIPTS_DIR/commands/bench/bench.sh" runtime kusama-dev pallet_referenda',
@@ -130,21 +130,21 @@ const dataProvider: DataProvider[] = [
     suitName: "nonexistent command, should return proper error",
     commandLine: "bot nope 123123",
     expectedResponse: new Error(
-      'Unknown command "nope"; Available ones are bench-all, bench-overhead, bench-vm, bench, fmt, merge, rebase, sample, try-runtime, update-ui. Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
+      'Unknown command "nope". Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     ),
   },
   {
     suitName: "not provided command, returns proper error",
     commandLine: "bot $",
     expectedResponse: new Error(
-      'Unknown command "$"; Available ones are bench-all, bench-overhead, bench-vm, bench, fmt, merge, rebase, sample, try-runtime, update-ui. Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
+      'Unknown command "$". Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     ),
   },
   {
     suitName: "non existed config must return error with explanation",
     commandLine: "bot xz",
     expectedResponse: new Error(
-      `Unknown command "xz"; Available ones are bench-all, bench-overhead, bench-vm, bench, fmt, merge, rebase, sample, try-runtime, update-ui. Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).`,
+      `Unknown command "xz". Refer to [help docs](http://cmd-bot.docs.com/static/docs/latest.html) and/or [source code](https://github.com/paritytech/command-bot-scripts).`,
     ),
   },
 ];

--- a/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
+++ b/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
@@ -33,8 +33,21 @@ export const cmd: CommandConfigs = {
         trappist: {
           description: "Pallet Benchmark for Trappist",
           repos: ["trappist"],
-          args: { runtime: { label: "Runtime", type_one_of: ["trappist", "stout"] } },
+          args: {
+            runtime: { label: "Runtime", type_one_of: ["trappist", "stout"] },
+            target_dir: { label: "Target Directory", type_string: "trappist" },
+          },
         },
+      },
+    },
+  },
+  "bench-bm": {
+    $schema: "../../node_modules/command-bot/src/schema/schema.cmd.json",
+    command: {
+      description: "This is a testing for `bench` command running on legacy BM machines",
+      configuration: {
+        gitlab: { job: { tags: ["weights-vm"], variables: {} } },
+        commandStart: ['"$PIPELINE_SCRIPTS_DIR/commands/bench-bm/bench-bm.sh"'],
       },
     },
   },
@@ -43,7 +56,7 @@ export const cmd: CommandConfigs = {
     command: {
       description: "Run benchmarks overhead and commit back results to PR",
       configuration: {
-        gitlab: { job: { tags: ["bench-bot"], variables: {} } },
+        gitlab: { job: { tags: ["weights-vm"], variables: {} } },
         commandStart: ['"$PIPELINE_SCRIPTS_DIR/commands/bench-overhead/bench-overhead.sh"'],
       },
       presets: {
@@ -76,22 +89,12 @@ export const cmd: CommandConfigs = {
       },
     },
   },
-  "bench-vm": {
-    $schema: "../../node_modules/command-bot/src/schema/schema.cmd.json",
-    command: {
-      description: "This is a testing for `bench` command running on VM machine",
-      configuration: {
-        gitlab: { job: { tags: ["weights-vm"], variables: {} } },
-        commandStart: ['"$PIPELINE_SCRIPTS_DIR/commands/bench-vm/bench-vm.sh"'],
-      },
-    },
-  },
   bench: {
     $schema: "../../node_modules/command-bot/src/schema/schema.cmd.json",
     command: {
       description: "Runs `benchmark pallet` or `benchmark overhead` against your PR and commits back updated weights",
       configuration: {
-        gitlab: { job: { tags: ["bench-bot"], variables: {} } },
+        gitlab: { job: { tags: ["weights-vm"], variables: {} } },
         commandStart: ['"$PIPELINE_SCRIPTS_DIR/commands/bench/bench.sh"'],
       },
       presets: {
@@ -202,6 +205,7 @@ export const cmd: CommandConfigs = {
             subcommand: { label: "Subcommand", type_one_of: ["runtime", "xcm"] },
             runtime: { label: "Runtime", type_one_of: ["trappist", "stout"] },
             pallet: { label: "Pallet", type_rule: "^([a-z_]+)([:]{2}[a-z_]+)?$", example: "pallet_name" },
+            target_dir: { label: "Target Directory", type_string: "trappist" },
           },
         },
       },
@@ -226,6 +230,7 @@ export const cmd: CommandConfigs = {
         gitlab: { job: { tags: [""] } },
         commandStart: ['"$PIPELINE_SCRIPTS_DIR/commands/merge/merge.sh"'],
       },
+      presets: { default: { description: "merge PR", repos: ["substrate", "polkadot", "cumulus"] } },
     },
   },
   rebase: {
@@ -234,9 +239,10 @@ export const cmd: CommandConfigs = {
       description:
         "create a merge commit from the target branch into the PR. Read more: https://github.com/paritytech/parity-processbot/",
       configuration: {
-        gitlab: { job: { tags: [""] } },
+        gitlab: { job: { tags: [""], variables: {} } },
         commandStart: ['"$PIPELINE_SCRIPTS_DIR/commands/rebase/rebase.sh"'],
       },
+      presets: { default: { description: "pull latest from the base", repos: ["substrate", "polkadot", "cumulus"] } },
     },
   },
   sample: {
@@ -291,6 +297,7 @@ export const cmd: CommandConfigs = {
             chain: { label: "Chain", type_one_of: ["trappist"] },
             chain_node: { label: "Chain Node", type_string: "trappist-node" },
             target_path: { label: "Target Path", type_string: "." },
+            live_uri: { label: "Live Node URI ID", type_string: "rococo-trappist" },
           },
         },
       },

--- a/src/command-configs/renderHelpPage.ts
+++ b/src/command-configs/renderHelpPage.ts
@@ -2,6 +2,7 @@ import path from "path";
 import * as pug from "pug";
 
 import { CommandConfigs } from "src/command-configs/types";
+import { getSupportedRepoNames } from "src/command-configs/utils";
 import { Config } from "src/config";
 import { CmdJson } from "src/schema/schema.cmd";
 
@@ -19,16 +20,7 @@ export function renderHelpPage(params: {
 
   const preparedConfigs = prepareConfigs(commandConfigs);
 
-  // getting list of possible repos, to be able to filter out relevant commands
-  const reposSet = new Set<string>();
-  for (const cmdConfig of Object.values(preparedConfigs)) {
-    for (const preset of Object.values(cmdConfig.command.presets ?? {})) {
-      for (const repo of preset.repos ?? []) {
-        reposSet.add(repo);
-      }
-    }
-  }
-  const repos = [...reposSet];
+  const repos = getSupportedRepoNames(preparedConfigs).repos;
 
   // TODO: depends on headBranch, if overridden: add `-v PIPELINE_SCRIPTS_REF=branch` to all command examples same for PATCH_repo=xxx
   // TODO: Simplify the PIPELINE_SCRIPTS_REF to something more rememberable */

--- a/src/command-configs/utils.spec.ts
+++ b/src/command-configs/utils.spec.ts
@@ -1,0 +1,54 @@
+import { CommandConfigs } from "src/command-configs/types";
+import { getSupportedRepoNames } from "src/command-configs/utils";
+import { CmdJson } from "src/schema/schema.cmd";
+
+type DataProvider = {
+  suitName: string;
+  configs: CommandConfigs;
+  result: { repos: string[]; includesGenericPresets: boolean };
+  presetName?: string;
+};
+
+function stubPresets(presets?: CmdJson["command"]["presets"]): CommandConfigs {
+  return {
+    cmd: {
+      command: { configuration: { gitlab: { job: { tags: [""] } } }, presets: presets ? { ...presets } : undefined },
+    },
+  };
+}
+
+const dataProvider: DataProvider[] = [
+  {
+    suitName: "test common preset without repos",
+    configs: stubPresets({ common: { description: "common", args: { arg1: { label: "1" } } } }),
+    result: { repos: [], includesGenericPresets: true },
+  },
+  {
+    suitName: "test repo specific preset with polkadot repo, no common presets",
+    configs: stubPresets({
+      repoSpecific: { repos: ["polkadot"], description: "polkadot", args: { arg1: { label: "1" } } },
+    }),
+    result: { repos: ["polkadot"], includesGenericPresets: false },
+  },
+  {
+    suitName: "test repo with both specific preset with polkadot repo and common one",
+    configs: stubPresets({
+      common: { description: "common", args: { arg1: { label: "1" } } },
+      repoSpecific: { repos: ["polkadot"], description: "1" },
+    }),
+    result: { repos: ["polkadot"], includesGenericPresets: true },
+  },
+  {
+    suitName: "test command without presets",
+    configs: stubPresets(),
+    result: { repos: [], includesGenericPresets: true },
+  },
+];
+
+describe("getSupportedRepoNames", () => {
+  for (const { suitName, configs, result, presetName } of dataProvider) {
+    test(`test commandLine: [${suitName}]`, () => {
+      expect(getSupportedRepoNames(configs, presetName)).toEqual(result);
+    });
+  }
+});

--- a/src/command-configs/utils.ts
+++ b/src/command-configs/utils.ts
@@ -1,0 +1,30 @@
+import { CommandConfigs } from "src/command-configs/types";
+
+// getting list of possible repos from command configs
+export function getSupportedRepoNames(
+  commandConfigs: CommandConfigs,
+  commandName?: string,
+): { repos: string[]; includesGenericPresets: boolean } {
+  let includesGenericPresets = false;
+  const reposSet = new Set<string>();
+  const commands = commandName ? [commandConfigs[commandName]] : Object.values(commandConfigs);
+  for (const cmdConfig of commands) {
+    const presets = Object.values(cmdConfig.command.presets ?? {});
+
+    if (presets.length === 0) {
+      includesGenericPresets = true;
+    }
+
+    for (const preset of presets) {
+      const repos = preset.repos ?? [];
+      // if repos are not specified, then this command is supported by all repos
+      if (repos.length === 0) {
+        includesGenericPresets = true;
+      }
+      for (const repo of preset.repos ?? []) {
+        reposSet.add(repo);
+      }
+    }
+  }
+  return { repos: Array.from(reposSet), includesGenericPresets };
+}

--- a/src/commander/commander.ts
+++ b/src/commander/commander.ts
@@ -41,7 +41,7 @@ export function getCommanderFromConfiguration(
 
   const exitOverride = (commandKey: string) => (e: CommanderError) => {
     if (e.code === "commander.excessArguments") {
-      throw new Error(((e as CommanderError).message = `Unknown subcommand of "${commandKey}". ${helpStr}`));
+      throw new Error(`Unknown subcommand of "${commandKey}". ${helpStr}`);
     }
     throw new Error((e as CommanderError).message.replace("error: ", ""));
   };

--- a/src/test/github-non-pipeline-cases.spec.ts
+++ b/src/test/github-non-pipeline-cases.spec.ts
@@ -53,7 +53,7 @@ const commandsDataProvider: CommandDataProviderItem[] = [
     commandLine: "testbot hrlp", // intentional typo
     expected: {
       startMessage:
-        '@somedev123 Unknown command "hrlp"; Available ones are bench-all, bench-bm, bench-overhead, bench, fmt, merge, rebase, sample, try-runtime, update-ui. Refer to [help docs](http://localhost:3000/static/docs/latest.html?repo=command-bot-test) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
+        '@somedev123 Unknown command "hrlp". Refer to [help docs](http://localhost:3000/static/docs/latest.html?repo=command-bot-test) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     },
   },
   {
@@ -61,13 +61,22 @@ const commandsDataProvider: CommandDataProviderItem[] = [
     commandLine: "testbot bench-all", // command-bot-test repo is not in a list of repos: [...] array
     expected: {
       startMessage:
-        '@somedev123 Missing arguments for command "bench-all". Refer to [help docs](http://localhost:3000/static/docs/latest.html?repo=command-bot-test) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
+        '@somedev123 Unknown command "bench-all". Refer to [help docs](http://localhost:3000/static/docs/latest.html?repo=command-bot-test) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
     },
   },
   {
     suitName: "[cancel] command for no jobs",
     commandLine: "testbot cancel",
     expected: { startMessage: "@somedev123 No task is being executed for this pull request" },
+  },
+
+  {
+    suitName: "[fmt] command with falsy args - won't be passed",
+    commandLine: "testbot fmt 1",
+    expected: {
+      startMessage:
+        '@somedev123 Unknown subcommand of "fmt". Refer to [help docs](http://localhost:3000/static/docs/latest.html?repo=command-bot-test) and/or [source code](https://github.com/paritytech/command-bot-scripts).',
+    },
   },
   // TODO: add test for clean after moving to opstooling-testing
   // {

--- a/src/test/github-positive-scenario.spec.ts
+++ b/src/test/github-positive-scenario.spec.ts
@@ -45,19 +45,9 @@ const commandsDataProvider: CommandDataProviderItem[] = [
     },
   },
   {
-    suitName: "[fmt] command with falsy args - won't be passed",
-    commandLine: "testbot fmt 1",
-    taskId: 2,
-    expected: {
-      startMessage:
-        'Preparing command ""$PIPELINE_SCRIPTS_DIR/commands/fmt/fmt.sh"". This comment will be updated later.',
-      finishMessage: '@somedev123 Command `"$PIPELINE_SCRIPTS_DIR/commands/fmt/fmt.sh"` has finished.',
-    },
-  },
-  {
     suitName: "[fmt] command no args",
     commandLine: "testbot fmt",
-    taskId: 3,
+    taskId: 2,
     expected: {
       startMessage:
         'Preparing command ""$PIPELINE_SCRIPTS_DIR/commands/fmt/fmt.sh"". This comment will be updated later.',
@@ -67,7 +57,7 @@ const commandsDataProvider: CommandDataProviderItem[] = [
   {
     suitName: "[bench-bot] command",
     commandLine: "testbot bench polkadot-pallet --runtime=kusama --pallet=pallet_referenda",
-    taskId: 4,
+    taskId: 3,
     expected: {
       startMessage:
         'Preparing command ""$PIPELINE_SCRIPTS_DIR/commands/bench/bench.sh" --subcommand=runtime --runtime=kusama --target_dir=polkadot --pallet=pallet_referenda". This comment will be updated later.',
@@ -78,7 +68,7 @@ const commandsDataProvider: CommandDataProviderItem[] = [
   {
     suitName: "[try-runtime] command",
     commandLine: "testbot try-runtime -v RUST_LOG=remote-ext=debug,runtime=trace --chain=kusama",
-    taskId: 5,
+    taskId: 4,
     expected: {
       startMessage:
         'Preparing command ""$PIPELINE_SCRIPTS_DIR/commands/try-runtime/try-runtime.sh" --chain=kusama --target_path=. --chain_node=polkadot',


### PR DESCRIPTION
Closes #233 
Tested locally 
<img width="845" alt="image" src="https://github.com/paritytech/command-bot/assets/1177472/106f4071-3173-4e1f-aa65-49e93cb19de4">

Also added validation of commands & subcommands in scope of repo - will fail with related message