### PR TITLE
Remove system parachain native runtimes after polkadot-sdk #1737

### DIFF
--- a/src/bot/parse/guessCommand.spec.ts
+++ b/src/bot/parse/guessCommand.spec.ts
@@ -24,16 +24,16 @@ const dataProvider: DataProvider[] = [
     result: "bot sample --input=args",
   },
   {
-    suitName: "cumulus assets polkadot",
-    command: "bench $ pallet asset-hub-polkadot assets pallet_xz",
+    suitName: "cumulus assets westend",
+    command: "bench $ pallet asset-hub-westend assets pallet_xz",
     repo: "polkadot-sdk",
     result: "bot bench cumulus-assets --pallet=pallet_xz",
   },
   {
-    suitName: "cumulus assets kusama",
+    suitName: "cumulus assets will end up with default as kusama no longer in repo",
     command: "bench $ pallet asset-hub-kusama assets pallet_xz",
     repo: "polkadot-sdk",
-    result: "bot bench cumulus-assets --runtime=asset-hub-kusama --pallet=pallet_xz",
+    result: "bot bench cumulus-assets --pallet=pallet_name",
   },
   {
     suitName: "cumulus assets old kusama: will endup with default, as can't find `statemine`",
@@ -53,20 +53,14 @@ const dataProvider: DataProvider[] = [
     repo: "polkadot-sdk",
     result: "bot bench polkadot-pallet --pallet=pallet_contracts",
   },
-  { suitName: "polkadot all", command: "bench-all $ kusama", repo: "polkadot", result: "bot bench-all polkadot" },
+  { suitName: "polkadot all", command: "bench-all $ rococo", repo: "polkadot", result: "bot bench-all polkadot" },
   {
-    suitName: "cumulus bridge-hubs",
-    command: "bench $ xcm bridge-hub-kusama bridge-hubs pallet_name",
+    suitName: "cumulus bridge-hubs default",
+    command: "bench $ xcm bridge-hub-rococo bridge-hubs pallet_name",
     repo: "cumulus",
-    result: "bot bench cumulus-bridge-hubs --subcommand=xcm --runtime=bridge-hub-kusama --pallet=pallet_name",
+    result: "bot bench cumulus-bridge-hubs --subcommand=xcm --pallet=pallet_name",
   },
-  {
-    suitName: "try-runtime default",
-    command: "try-runtime $ westend",
-    repo: "polkadot",
-    result: "bot try-runtime --chain=westend",
-  },
-  { suitName: "try-runtime default", command: "try-runtime $ polkadot", repo: "polkadot", result: "bot try-runtime" },
+  { suitName: "try-runtime default", command: "try-runtime $ westend", repo: "polkadot", result: "bot try-runtime" },
 ];
 
 describe("guessCommand", () => {

--- a/src/bot/parse/parsePullRequestBotCommandLine.namedArgs.spec.ts
+++ b/src/bot/parse/parsePullRequestBotCommandLine.namedArgs.spec.ts
@@ -28,13 +28,13 @@ const dataProvider: DataProvider[] = [
         gitlab: { job: { tags: ["weights-vm"], variables: {} } },
       },
       {},
-      '"$PIPELINE_SCRIPTS_DIR/commands/bench/bench.sh" --subcommand=runtime --runtime=polkadot --target_dir=polkadot --pallet=pallet_referenda',
+      '"$PIPELINE_SCRIPTS_DIR/commands/bench/bench.sh" --subcommand=runtime --runtime=westend --target_dir=polkadot --pallet=pallet_referenda',
     ),
   },
   {
     suitName: "bench-bot cumulus",
     commandLine:
-      "bot bench cumulus-bridge-hubs -v PIPELINE_SCRIPTS_REF=branch --subcommand=xcm --runtime=bridge-hub-kusama --pallet=pallet_name",
+      "bot bench cumulus-bridge-hubs -v PIPELINE_SCRIPTS_REF=branch --subcommand=xcm --runtime=bridge-hub-rococo --pallet=pallet_name",
     expectedResponse: new GenericCommand(
       "bench",
       {
@@ -42,7 +42,7 @@ const dataProvider: DataProvider[] = [
         gitlab: { job: { tags: ["weights-vm"], variables: {} } },
       },
       { PIPELINE_SCRIPTS_REF: "branch" },
-      '"$PIPELINE_SCRIPTS_DIR/commands/bench/bench.sh" --subcommand=xcm --runtime=bridge-hub-kusama --runtime_dir=bridge-hubs --target_dir=cumulus --pallet=pallet_name',
+      '"$PIPELINE_SCRIPTS_DIR/commands/bench/bench.sh" --subcommand=xcm --runtime=bridge-hub-rococo --runtime_dir=bridge-hubs --target_dir=cumulus --pallet=pallet_name',
     ),
     repo: "cumulus",
   },
@@ -53,7 +53,7 @@ const dataProvider: DataProvider[] = [
   },
   {
     suitName: "try-runtime-bot testing default without mentioning preset name",
-    commandLine: "bot try-runtime -v RUST_LOG=remote-ext=debug,runtime=trace -v SECOND=val --chain=kusama",
+    commandLine: "bot try-runtime -v RUST_LOG=remote-ext=debug,runtime=trace -v SECOND=val --chain=rococo",
     expectedResponse: new GenericCommand(
       "try-runtime",
       {
@@ -61,7 +61,7 @@ const dataProvider: DataProvider[] = [
         gitlab: { job: { tags: ["linux-docker-vm-c2"], variables: {} } },
       },
       { RUST_LOG: "remote-ext=debug,runtime=trace", SECOND: "val" },
-      '"$PIPELINE_SCRIPTS_DIR/commands/try-runtime/try-runtime.sh" --chain=kusama --target_path=. --chain_node=polkadot',
+      '"$PIPELINE_SCRIPTS_DIR/commands/try-runtime/try-runtime.sh" --chain=rococo --target_path=. --chain_node=polkadot',
     ),
   },
   {
@@ -74,7 +74,7 @@ const dataProvider: DataProvider[] = [
         gitlab: { job: { tags: ["linux-docker-vm-c2"], variables: {} } },
       },
       {},
-      '"$PIPELINE_SCRIPTS_DIR/commands/try-runtime/try-runtime.sh" --chain=polkadot --target_path=. --chain_node=polkadot',
+      '"$PIPELINE_SCRIPTS_DIR/commands/try-runtime/try-runtime.sh" --chain=westend --target_path=. --chain_node=polkadot',
     ),
   },
   {
@@ -311,9 +311,9 @@ const dataProvider: DataProvider[] = [
   },
   {
     suitName: "non existed config must return error with explanation",
-    commandLine: "bot bench-overhead $ kusama",
+    commandLine: "bot bench-overhead $ rococo",
     expectedResponse: new Error(
-      `Positional arguments are not supported anymore. I guess you meant \`bot bench-overhead --runtime=kusama\`, but I could be wrong.\n[Read docs](http://cmd-bot.docs.com/static/docs/latest.html) to find out how to run your command.`,
+      `Positional arguments are not supported anymore. I guess you meant \`bot bench-overhead --runtime=rococo\`, but I could be wrong.\n[Read docs](http://cmd-bot.docs.com/static/docs/latest.html) to find out how to run your command.`,
     ),
   },
 ];

--- a/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
+++ b/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
@@ -145,10 +145,7 @@ export const cmd: CommandConfigs = {
           repos: ["cumulus", "polkadot-sdk"],
           args: {
             subcommand: { label: "Subcommand", type_one_of: ["pallet", "xcm"] },
-            runtime: {
-              label: "Runtime",
-              type_one_of: ["bridge-hub-rococo"],
-            },
+            runtime: { label: "Runtime", type_one_of: ["bridge-hub-rococo"] },
             pallet: { label: "Pallet", type_rule: "^([a-z_]+)([:]{2}[a-z_]+)?$", example: "pallet_name" },
             runtime_dir: { label: "Runtime Dir", type_string: "bridge-hubs" },
             target_dir: { label: "Target Directory", type_string: "cumulus" },

--- a/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
+++ b/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
@@ -77,7 +77,7 @@ export const cmd: CommandConfigs = {
           description: "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
           repos: ["cumulus", "polkadot-sdk"],
           args: {
-            runtime: { label: "Runtime", type_one_of: ["asset-hub-polkadot", "asset-hub-kusama", "asset-hub-westend"] },
+            runtime: { label: "Runtime", type_one_of: ["asset-hub-westend"] },
             target_dir: { label: "Target Directory", type_string: "cumulus" },
           },
         },
@@ -123,7 +123,7 @@ export const cmd: CommandConfigs = {
           repos: ["cumulus", "polkadot-sdk"],
           args: {
             subcommand: { label: "Subcommand", type_one_of: ["pallet", "xcm"] },
-            runtime: { label: "Runtime", type_one_of: ["asset-hub-polkadot", "asset-hub-kusama", "asset-hub-westend"] },
+            runtime: { label: "Runtime", type_one_of: ["asset-hub-westend"] },
             pallet: { label: "Pallet", type_rule: "^([a-z_]+)([:]{2}[a-z_]+)?$", example: "pallet_name" },
             runtime_dir: { label: "Runtime Dir", type_string: "assets" },
             target_dir: { label: "Target Directory", type_string: "cumulus" },
@@ -134,7 +134,7 @@ export const cmd: CommandConfigs = {
           repos: ["cumulus", "polkadot-sdk"],
           args: {
             subcommand: { label: "Subcommand", type_one_of: ["pallet", "xcm"] },
-            runtime: { label: "Runtime", type_one_of: ["collectives-polkadot"] },
+            runtime: { label: "Runtime", type_one_of: ["collectives-westend"] },
             pallet: { label: "Pallet", type_rule: "^([a-z_]+)([:]{2}[a-z_]+)?$", example: "pallet_name" },
             runtime_dir: { label: "Runtime Dir", type_string: "collectives" },
             target_dir: { label: "Target Directory", type_string: "cumulus" },
@@ -147,7 +147,7 @@ export const cmd: CommandConfigs = {
             subcommand: { label: "Subcommand", type_one_of: ["pallet", "xcm"] },
             runtime: {
               label: "Runtime",
-              type_one_of: ["bridge-hub-polkadot", "bridge-hub-kusama", "bridge-hub-rococo"],
+              type_one_of: ["bridge-hub-rococo"],
             },
             pallet: { label: "Pallet", type_rule: "^([a-z_]+)([:]{2}[a-z_]+)?$", example: "pallet_name" },
             runtime_dir: { label: "Runtime Dir", type_string: "bridge-hubs" },
@@ -170,7 +170,7 @@ export const cmd: CommandConfigs = {
           repos: ["cumulus", "polkadot-sdk"],
           args: {
             subcommand: { label: "Subcommand", type_one_of: ["pallet"] },
-            runtime: { label: "Runtime", type_one_of: ["glutton-kusama", "glutton-kusama-dev-1300"] },
+            runtime: { label: "Runtime", type_one_of: ["glutton-westend", "glutton-westend-dev-1300"] },
             pallet: { label: "Pallet", type_rule: "^([a-z_]+)([:]{2}[a-z_]+)?$", example: "pallet_name" },
             runtime_dir: { label: "Runtime Dir", type_string: "glutton" },
             target_dir: { label: "Target Directory", type_string: "cumulus" },

--- a/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
+++ b/src/command-configs/__mocks__/fetchCommandsConfiguration.ts
@@ -21,7 +21,7 @@ export const cmd: CommandConfigs = {
           description: "Pallet + Overhead Benchmark for Polkadot",
           repos: ["polkadot", "polkadot-sdk"],
           args: {
-            runtime: { label: "Runtime", type_one_of: ["kusama", "polkadot", "rococo", "westend"] },
+            runtime: { label: "Runtime", type_one_of: ["rococo", "westend"] },
             target_dir: { label: "Target Directory", type_string: "polkadot" },
           },
         },
@@ -64,7 +64,7 @@ export const cmd: CommandConfigs = {
           description: "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
           repos: ["polkadot", "polkadot-sdk"],
           args: {
-            runtime: { label: "Runtime", type_one_of: ["polkadot", "kusama", "rococo", "westend"] },
+            runtime: { label: "Runtime", type_one_of: ["westend", "rococo"] },
             target_dir: { label: "Target Directory", type_string: "polkadot" },
           },
         },
@@ -113,7 +113,7 @@ export const cmd: CommandConfigs = {
           repos: ["polkadot", "command-bot-test", "polkadot-sdk"],
           args: {
             subcommand: { label: "Subcommand", type_one_of: ["runtime", "xcm"] },
-            runtime: { label: "Runtime", type_one_of: ["polkadot", "kusama", "rococo", "westend"] },
+            runtime: { label: "Runtime", type_one_of: ["westend", "rococo"] },
             pallet: { label: "Pallet", type_rule: "^([a-z_]+)([:]{2}[a-z_]+)?$", example: "pallet_name" },
             target_dir: { label: "Target Directory", type_string: "polkadot" },
           },
@@ -276,7 +276,7 @@ export const cmd: CommandConfigs = {
           description: "Run try-runtime with specified runtime for Polkadot repo",
           repos: ["polkadot", "command-bot-test"],
           args: {
-            chain: { label: "Chain", type_one_of: ["polkadot", "kusama", "westend", "rococo"] },
+            chain: { label: "Chain", type_one_of: ["westend", "rococo"] },
             target_path: { label: "Target Path", type_string: "." },
             chain_node: { label: "Chain Node", type_string: "polkadot" },
           },
@@ -285,7 +285,7 @@ export const cmd: CommandConfigs = {
           description: "Run try-runtime with specified runtime for monorepo Polkadot SDK",
           repos: ["polkadot-sdk"],
           args: {
-            chain: { label: "Chain", type_one_of: ["polkadot", "kusama", "westend", "rococo"] },
+            chain: { label: "Chain", type_one_of: ["westend", "rococo"] },
             target_path: { label: "Target Path", type_string: "./polkadot" },
             chain_node: { label: "Chain Node", type_string: "polkadot" },
           },


### PR DESCRIPTION
Changes related to #242.

Removes arguments for benchmarks for the following:
- `asset-hub-kusama` and `asset-hub-polkadot`
- `bridge-hub-kusama` and `bridge-hub-polkadot`
- `collectives-polkadot`
- `glutton-kusama`

Adds arguments for 
- `collectives-westend`
- `glutton-westend`

To be merged after [this PR](https://github.com/paritytech/polkadot-sdk/pull/1737) in `polkadot-sdk` and along with [this PR](https://github.com/paritytech/command-bot-scripts/pull/52) in `command-bot-scripts`