### PR TITLE
support setting a timeout for a job

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -144,7 +144,8 @@ export const setupApi = (ctx: Context, server: Server): void => {
       command,
       gitlab: {
         job: {
-          ...configuration.gitlab.job,
+          timeout: "24 hours",
+          ...configuration.gitlab.job, // might override default timeout
           variables: { ...configuration.gitlab.job.variables, ...variables },
           image: gitlab.defaultJobImage,
         },

--- a/src/bot/events/handlers/genericHandler.ts
+++ b/src/bot/events/handlers/genericHandler.ts
@@ -81,6 +81,9 @@ export async function genericHandler(this: EventHandler): Promise<PullRequestErr
     gitlab: {
       job: {
         image,
+        ...(typeof parsedCommand.configuration.gitlab?.job.timeout === "string"
+          ? { timeout: parsedCommand.configuration.gitlab.job.timeout }
+          : {}),
         tags: parsedCommand.configuration.gitlab?.job.tags || [],
         variables: Object.assign(defaultVariables, overriddenVariables),
       },

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -117,8 +117,8 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task): Prom
     registered the branch, therefore causing the "Reference not found" message.
   */
   let wasBranchRegistered = false;
-  const waitForBranchMaxTries = 3;
-  const waitForBranchRetryDelayMs = 2000;
+  const waitForBranchMaxTries = 5;
+  const waitForBranchRetryDelayMs = 5000;
 
   const branchPresenceUrl = `${gitlabProjectApi}/repository/branches/${branchNameUrlEncoded}`;
 

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -166,6 +166,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task): Prom
           .keys({ id: Joi.number().required(), project_id: Joi.number().required() })
           .options({ allowUnknown: true }),
       ),
+    { attempts: waitForBranchMaxTries, timeoutMs: waitForBranchRetryDelayMs },
   );
 
   logger.info({ pipeline, task }, `Created pipeline for task ${task.id}`);

--- a/src/gitlab/createCiConfig.ts
+++ b/src/gitlab/createCiConfig.ts
@@ -12,7 +12,7 @@ export function createCiConfig(
     workflow: { rules: [{ if: `$CI_PIPELINE_SOURCE == "api"` }, { if: `$CI_PIPELINE_SOURCE == "web"` }] },
     command: {
       timeout: "24 hours",
-      ...task.gitlab.job,
+      ...task.gitlab.job, // timeout could be overridden from the command configs
       script: [
         ...`
         echo "This job is related to task ${task.id}. ${jobTaskInfoMessage}."

--- a/src/schema/schema.cmd.json
+++ b/src/schema/schema.cmd.json
@@ -21,6 +21,9 @@
                 "job": {
                   "type": "object",
                   "properties": {
+                    "timeout": {
+                      "type": "string"
+                    },
                     "tags": {
                       "type": "array",
                       "items": {

--- a/src/task.ts
+++ b/src/task.ts
@@ -37,6 +37,7 @@ type TaskBase<T> = {
   requester: string;
   gitlab: {
     job: {
+      timeout?: string;
       tags: string[];
       image: string;
       variables: {

--- a/src/test/github-job-failure.spec.ts
+++ b/src/test/github-job-failure.spec.ts
@@ -90,7 +90,7 @@ describe("Job failure (GitHub webhook)", () => {
       .forGet("/api/v4/projects/paritytech-stg%2Fcommand-bot-test/pipelines/61/jobs")
       .thenReply(200, restFixures.gitlab.jobs, jsonResponseHeaders);
 
-    await until(async () => !(await mockedPipelineEndpoint.isPending()), 150, 50);
+    await until(async () => !(await mockedPipelineEndpoint.isPending()), 250, 50);
   });
 
   test("Phase 2: pipeline fails", async () => {
@@ -105,7 +105,7 @@ describe("Job failure (GitHub webhook)", () => {
       .forPost("/api/v4/projects/1/pipelines/61/cancel")
       .thenReply(200, restFixures.gitlab.cancelledPipeline, jsonResponseHeaders);
 
-    await until(async () => !(await mockedEndpoint.isPending()), 100, 50);
+    await until(async () => !(await mockedEndpoint.isPending()), 250, 50);
   });
 
   // TODO: bot should comment about status of the job

--- a/src/test/github-positive-scenario.spec.ts
+++ b/src/test/github-positive-scenario.spec.ts
@@ -170,7 +170,7 @@ describe.each(commandsDataProvider)(
         .forGet("/api/v4/projects/paritytech-stg%2Fcommand-bot-test/pipelines/61/jobs")
         .thenReply(200, restFixtures.gitlab.jobs, jsonResponseHeaders);
 
-      await until(async () => !(await mockedPipelineEndpoint.isPending()), 100, 50);
+      await until(async () => !(await mockedPipelineEndpoint.isPending()), 200, 50);
     });
 
     test("Phase 3: cmd-bot updates the comment with a link to the pipeline", async () => {

--- a/src/test/github-positive-scenario.spec.ts
+++ b/src/test/github-positive-scenario.spec.ts
@@ -170,7 +170,7 @@ describe.each(commandsDataProvider)(
         .forGet("/api/v4/projects/paritytech-stg%2Fcommand-bot-test/pipelines/61/jobs")
         .thenReply(200, restFixtures.gitlab.jobs, jsonResponseHeaders);
 
-      await until(async () => !(await mockedPipelineEndpoint.isPending()), 200, 50);
+      await until(async () => !(await mockedPipelineEndpoint.isPending()), 250, 50);
     });
 
     test("Phase 3: cmd-bot updates the comment with a link to the pipeline", async () => {

--- a/src/test/setup/integration.setupAfterEnv.ts
+++ b/src/test/setup/integration.setupAfterEnv.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
   await launchBot(mockServers.gitHub.url, mockServers.gitLab.url, gitDaemons);
   console.log("Bot launched");
 
-  await delay(1000);
+  await delay(2000);
 });
 
 afterAll(async () => {
@@ -34,5 +34,5 @@ afterAll(async () => {
   await stopMockServers();
   console.log("MockServers stopped");
 
-  await delay(1000);
+  await delay(2000);
 });


### PR DESCRIPTION
Some jobs would require an increased expected timeout to run. The sync for example

sync command: https://github.com/paritytech/command-bot-scripts/pull/53

<img width="854" alt="image" src="https://github.com/paritytech/command-bot/assets/1177472/e1c2b771-0343-437f-a3e0-c343aa296e3b">
