### PR TITLE
Bump `ci-unified` to `v20240103`

### DIFF
--- a/helm/values-parity-prod.yaml
+++ b/helm/values-parity-prod.yaml
@@ -12,7 +12,7 @@ gcloud-sqlproxy:
 common:
   env:
     GITLAB_PUSH_NAMESPACE: parity/mirrors
-    GITLAB_JOB_IMAGE: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20231204
+    GITLAB_JOB_IMAGE: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20240103
     GITLAB_DOMAIN: gitlab.parity.io
     DATA_PATH: /data
     IS_DEPLOYMENT: true

--- a/helm/values-parity-stg.yaml
+++ b/helm/values-parity-stg.yaml
@@ -12,7 +12,7 @@ gcloud-sqlproxy:
 common:
   env:
     GITLAB_PUSH_NAMESPACE: parity/mirrors
-    GITLAB_JOB_IMAGE: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20231204
+    GITLAB_JOB_IMAGE: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20240103
     GITLAB_DOMAIN: gitlab-stg.parity.io
     DATA_PATH: /data
     IS_DEPLOYMENT: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,7 +41,7 @@ common:
       - ReadWriteOnce
   env:
     GITLAB_PUSH_NAMESPACE: parity/mirrors
-    GITLAB_JOB_IMAGE: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20231204
+    GITLAB_JOB_IMAGE: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20240103
     GITLAB_DOMAIN: gitlab.parity.io
     PIPELINE_SCRIPTS_REPOSITORY: https://github.com/paritytech/command-bot-scripts/
     PIPELINE_SCRIPTS_REF: main

--- a/src/command-configs/help/parts/commands.pug
+++ b/src/command-configs/help/parts/commands.pug
@@ -43,11 +43,11 @@ div(id="link-override-ci-image").command
 
   p Syntax (after command name):
   p
-    code -v CMD_IMAGE=paritytech/ci-unified:bullseye-1.73.0-2023-11-01-v20231204
+    code -v CMD_IMAGE=paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20240103
 
   p Examples:
   p
-    code #{commandStart} update-ui -v CMD_IMAGE=paritytech/ci-unified:bullseye-1.73.0-2023-11-01-v20231204 --rust_version=1.73.0
+    code #{commandStart} update-ui -v CMD_IMAGE=paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20240103 --rust_version=1.74.0
 
 div(id="link-rust").command
   h5 Rust Log, etc


### PR DESCRIPTION
A usual followup after bumping the image  in the `polkadot-sdk` CI.